### PR TITLE
feat: add Yandex Cloud compute provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ green/
 │   └── resources/io/github/bigconfig-ai/once/
 │       ├── raw              # `<{ content|safe }>` — the template used for generated content
 │       └── tools/
-│           ├── tofu/{digitalocean,hcloud,oci,no-infra}/main.tf
+│           ├── tofu/{digitalocean,hcloud,oci,yandex,no-infra}/main.tf
 │           ├── tofu-smtp/{resend,no-infra}/main.tf
 │           ├── tofu-dns/{cloudflare,no-infra}/main.tf
 │           ├── tofu-smtp-post/{resend,no-infra}/main.tf
@@ -88,7 +88,7 @@ A single flat EDN map, except for the nested `:once {:applications [...]}` colle
  :once {:applications [{:host "www.example.com"
                         :image "ghcr.io/example/site:latest"
                         :env {"DATABASE_URL" :app-database-url}}]}
- :provider-compute "digitalocean"  ; digitalocean | hcloud | oci | no-infra
+ :provider-compute "digitalocean"  ; digitalocean | hcloud | oci | yandex | no-infra
  :provider-smtp "resend"           ; resend | no-infra
  :provider-dns "cloudflare"        ; cloudflare | no-infra
  :provider-backend "r2"            ; local | s3 | r2

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ nested `:once {:applications [...]}` collection:
  :once {:applications [{:host "www.example.com"
                         :image "ghcr.io/example/site:latest"
                         :env {"DATABASE_URL" :app-database-url}}]}
- :provider-compute "digitalocean" ; digitalocean, hcloud, oci, no-infra
+ :provider-compute "digitalocean" ; digitalocean, hcloud, oci, yandex, no-infra
  :provider-smtp "resend"          ; resend, no-infra
  :provider-dns "cloudflare"       ; cloudflare, no-infra
  :provider-backend "r2"           ; r2, s3, local
@@ -97,6 +97,7 @@ the value it replaces:
 
 ```bash
 export GREEN_PAR_DO_TOKEN="..."
+export GREEN_PAR_YC_TOKEN="..."
 export GREEN_PAR_CLOUDFLARE_API_TOKEN="..."
 export GREEN_PAR_RESEND_API_KEY="..."
 export GREEN_PAR_RESEND_PASSWORD="..."
@@ -148,8 +149,8 @@ soft failures; a missing remote `once` command produces a non-zero exit.
 
 ## Providers and generated configuration
 
-- Compute templates: DigitalOcean, Hetzner Cloud, OCI, and an existing
-  `no-infra` host.
+- Compute templates: DigitalOcean, Hetzner Cloud, OCI, Yandex Cloud, and an
+  existing `no-infra` host.
 - SMTP templates: Resend or `no-infra` SMTP settings.
 - DNS templates: Cloudflare or `no-infra`; the per-application and Resend DNS
   records are generated as `apps.tf.json` and `smtp.tf.json` at the

--- a/bb.edn
+++ b/bb.edn
@@ -1,2 +1,4 @@
-{:deps {io.github.amiorin/green      {:local/root "/home/ubuntu/code/green"}
+{:deps {io.github.amiorin/green      {:git/url "https://github.com/amiorin/green.git"
+                                      :git/sha "1bcee232c98a9562d12a795c03978094ccc7a7cc"}
+        #_#_io.github.amiorin/green  {:local/root "/home/ubuntu/code/green"}
         io.github.bigconfig-ai/once {:local/root "."}}}

--- a/green-once/green
+++ b/green-once/green
@@ -31,7 +31,7 @@
   "Minimum io.github.bigconfig-ai/once contract this launcher requires.
   Guarded at run time so a stale pin fails loudly instead of rendering
   templates from an older commit."
-  3)
+  4)
 
 ;; Managed by `green pin` — do not edit by hand.
 (def ^:private once-sha "03ac70a9814d024573bd21ae37b33ebaaf0d054c")
@@ -96,7 +96,7 @@
   [k]
   (str "GREEN_PAR_" (-> (name k) str/upper-case (str/replace "-" "_"))))
 
-(def ^:private compute-providers #{"digitalocean" "hcloud" "oci" "no-infra"})
+(def ^:private compute-providers #{"digitalocean" "hcloud" "oci" "yandex" "no-infra"})
 (def ^:private smtp-providers #{"resend" "no-infra"})
 (def ^:private dns-providers #{"cloudflare" "no-infra"})
 (def ^:private backend-providers #{"local" "s3" "r2"})
@@ -111,6 +111,12 @@
           :oci-availability-domain :oci-display-name :oci-shape :oci-ocpus
           :oci-memory-in-gbs :oci-boot-volume-size-in-gbs
           :oci-boot-volume-vpus-per-gb :oci-ssh-authorized-keys]
+   ;; Yandex has no account-level SSH key registry, so :compute-pubkey is
+   ;; interpolated into instance metadata and becomes required here.
+   "yandex" [:compute-pubkey :yandex-cloud-id :yandex-folder-id :yandex-zone
+             :yandex-name :yandex-platform-id :yandex-cores :yandex-memory-gb
+             :yandex-core-fraction :yandex-image-family :yandex-disk-size-gb
+             :yandex-subnet-cidr]
    "no-infra" [:no-infra-compute-ip :no-infra-compute-user
                :no-infra-compute-sudoer :no-infra-compute-uid]})
 
@@ -128,7 +134,8 @@
 
 ;; Credential keys, expected from GREEN_PAR_* rather than green.edn.
 (def ^:private compute-secrets
-  {"digitalocean" [:do-token] "hcloud" [:hcloud-token] "oci" [] "no-infra" []})
+  {"digitalocean" [:do-token] "hcloud" [:hcloud-token] "oci" []
+   "yandex" [:yc-token] "no-infra" []})
 
 (def ^:private smtp-secrets
   {"resend" [:resend-api-key :resend-password]

--- a/green-once/references/configuration.md
+++ b/green-once/references/configuration.md
@@ -35,7 +35,7 @@ There is no domain key. The application hostnames are the source of truth: the D
 
 `:deploy-pubkey` is required. It authorizes only `sudo once update <configured-host>` through a remote ForceCommand. Private keys remain outside the project and should be loaded in `ssh-agent`.
 
-`:compute-pubkey` is accepted but currently unused: each compute provider references a key already registered with it (`:digitalocean-ssh-keys`, `:hcloud-ssh-keys`) or a local public-key file (`:oci-ssh-authorized-keys`). If present it must still look like a public key.
+`:compute-pubkey` is consumed only by the Yandex provider, which has no account-level key registry: the key is written into instance metadata for the `ubuntu` user, so it is required when `:provider-compute` is `"yandex"`. The other cloud providers reference a key already registered with them (`:digitalocean-ssh-keys`, `:hcloud-ssh-keys`) or a local public-key file (`:oci-ssh-authorized-keys`). If present it must still look like a public key.
 
 ## Compute providers
 
@@ -85,6 +85,26 @@ Required credential: `GREEN_PAR_HCLOUD_TOKEN`.
 ```
 
 No credential variable is required: OCI authenticates through the named profile in `~/.oci/config`. `:oci-ssh-authorized-keys` is a path to a public-key file on the machine running the launcher, read at plan time.
+
+### Yandex Cloud
+
+```clojure
+:provider-compute "yandex"
+:compute-pubkey "ssh-ed25519 AAAA... admin"
+:yandex-cloud-id "b1g..."
+:yandex-folder-id "b1g..."
+:yandex-zone "ru-central1-a"
+:yandex-name "once"
+:yandex-platform-id "standard-v3"
+:yandex-cores 2
+:yandex-memory-gb 4
+:yandex-core-fraction 100
+:yandex-image-family "ubuntu-2404-lts"
+:yandex-disk-size-gb 30
+:yandex-subnet-cidr "10.10.0.0/24"
+```
+
+Required credential: `GREEN_PAR_YC_TOKEN` (an OAuth or IAM token; `yc iam create-token` issues one). The template is self-contained: it creates a VPC network and subnet with the given CIDR, resolves the newest image of `:yandex-image-family`, and provisions the VM with a NAT'd public address. Yandex has no account-level SSH key registry, so `:compute-pubkey` is required and is written into instance metadata as the `ubuntu` user's authorized key. Yandex Object Storage can hold the OpenTofu state through the `r2` backend with `:r2-endpoint "https://storage.yandexcloud.net"` and a service-account static key.
 
 ### Existing server
 

--- a/green.edn
+++ b/green.edn
@@ -9,6 +9,7 @@
 ;;   digitalocean   GREEN_PAR_DO_TOKEN
 ;;   hcloud         GREEN_PAR_HCLOUD_TOKEN
 ;;   oci            (none — uses :oci-config-file-profile from ~/.oci/config)
+;;   yandex         GREEN_PAR_YC_TOKEN
 ;;   resend         GREEN_PAR_RESEND_API_KEY GREEN_PAR_RESEND_PASSWORD
 ;;   no-infra smtp  GREEN_PAR_NO_INFRA_SMTP_PASSWORD
 ;;   cloudflare     GREEN_PAR_CLOUDFLARE_API_TOKEN
@@ -71,6 +72,21 @@
  :digitalocean-image "ubuntu-25-10-x64"
  :digitalocean-vpc-uuid "REPLACE_ME"
  :digitalocean-ssh-keys "REPLACE_ME"
+
+ ;; Yandex is the one compute provider that consumes :compute-pubkey — the
+ ;; account has no SSH key registry, so the key is written into instance
+ ;; metadata for the ubuntu user.
+ :yandex-cloud-id "REPLACE_ME"
+ :yandex-folder-id "REPLACE_ME"
+ :yandex-zone "ru-central1-a"
+ :yandex-name "once"
+ :yandex-platform-id "standard-v3"
+ :yandex-cores 2
+ :yandex-memory-gb 4
+ :yandex-core-fraction 100
+ :yandex-image-family "ubuntu-2404-lts"
+ :yandex-disk-size-gb 30
+ :yandex-subnet-cidr "10.10.0.0/24"
 
  :no-infra-compute-ip "REPLACE_ME"
  :no-infra-compute-user "REPLACE_ME"

--- a/index.html
+++ b/index.html
@@ -838,6 +838,7 @@ GREEN_PAR_DIGITALOCEAN_SIZE=s-2vcpu-2gb ./green create --dry-run</code></pre>
             <tr><td>DigitalOcean</td><td><code>GREEN_PAR_DO_TOKEN</code></td><td>Create and delete</td></tr>
             <tr><td>Hetzner Cloud</td><td><code>GREEN_PAR_HCLOUD_TOKEN</code></td><td>Create and delete</td></tr>
             <tr><td>Oracle Cloud</td><td>None — authenticates through the <code>:oci-config-file-profile</code> entry in <code>~/.oci/config</code></td><td>—</td></tr>
+            <tr><td>Yandex Cloud</td><td><code>GREEN_PAR_YC_TOKEN</code></td><td>Create and delete</td></tr>
             <tr><td>Resend</td><td><code>GREEN_PAR_RESEND_API_KEY</code>, <code>GREEN_PAR_RESEND_PASSWORD</code></td><td>Create and delete</td></tr>
             <tr><td>Existing SMTP</td><td><code>GREEN_PAR_NO_INFRA_SMTP_PASSWORD</code></td><td>Create and delete</td></tr>
             <tr><td>Cloudflare DNS</td><td><code>GREEN_PAR_CLOUDFLARE_API_TOKEN</code></td><td>Create and delete</td></tr>
@@ -900,6 +901,22 @@ done</code></pre>
 :oci-boot-volume-vpus-per-gb 30
 :oci-ssh-authorized-keys "/home/user/.ssh/once.pub"</code></pre>
       <p>The current default shape is ARM-based. <code>:oci-ssh-authorized-keys</code> is a path to a public-key file on the machine running the launcher; its contents are written into instance metadata at plan time. OCI authenticates through the named profile in <code>~/.oci/config</code>, so no credential variable is required.</p>
+
+      <h3>Yandex Cloud</h3>
+      <pre><code class="language-clojure">:provider-compute "yandex"
+:compute-pubkey "ssh-ed25519 AAAA... admin"
+:yandex-cloud-id "b1g..."
+:yandex-folder-id "b1g..."
+:yandex-zone "ru-central1-a"
+:yandex-name "once"
+:yandex-platform-id "standard-v3"
+:yandex-cores 2
+:yandex-memory-gb 4
+:yandex-core-fraction 100
+:yandex-image-family "ubuntu-2404-lts"
+:yandex-disk-size-gb 30
+:yandex-subnet-cidr "10.10.0.0/24"</code></pre>
+      <p>Self-contained: creates a VPC network and subnet with the given CIDR, resolves the newest image of <code>:yandex-image-family</code>, and provisions the VM with a NAT'd public address. Yandex has no account-level SSH key registry, so <code>:compute-pubkey</code> is required here — it is written into instance metadata as the <code>ubuntu</code> user's authorized key. Credential: <code>GREEN_PAR_YC_TOKEN</code>. Yandex Object Storage can hold the OpenTofu state through the <code>r2</code> backend with <code>:r2-endpoint "https://storage.yandexcloud.net"</code>.</p>
 
       <h3>Existing server</h3>
       <pre><code class="language-clojure">:provider-compute "no-infra"

--- a/src/clj/io/github/bigconfig_ai/once/tools.clj
+++ b/src/clj/io/github/bigconfig_ai/once/tools.clj
@@ -56,6 +56,7 @@
   files, where they would sit in plaintext under the work directory."
   {:do-token "DIGITALOCEAN_TOKEN"
    :hcloud-token "HCLOUD_TOKEN"
+   :yc-token "YC_TOKEN"
    :resend-api-key "RESEND_API_KEY"
    :cloudflare-api-token "CLOUDFLARE_API_TOKEN"
    :r2-access-key-id "AWS_ACCESS_KEY_ID"
@@ -122,6 +123,11 @@
              :uid "1001"
              :name name
              :user "ubuntu"}
+      "yandex" {:ip "192.168.0.1"
+                :sudoer "ubuntu"
+                :uid "1000"
+                :name name
+                :user "ubuntu"}
       "no-infra" (cond-> {:ip (or (:no-infra-compute-ip opts) "192.168.0.1")
                             :sudoer (or (:no-infra-compute-sudoer opts) "root")
                             :name name
@@ -159,7 +165,7 @@
                               (str dir "/main.tf")
                               opts)]]
     (tofu-with-spec opts dir specs (fallback-compute-params opts) :once/compute-params
-                    (credential-env opts [:do-token :hcloud-token]))))
+                    (credential-env opts [:do-token :hcloud-token :yc-token]))))
 
 (defn- with-zone
   "Templates that name the DNS zone read `zone`, which no key in desired state

--- a/src/clj/io/github/bigconfig_ai/once/utils.clj
+++ b/src/clj/io/github/bigconfig_ai/once/utils.clj
@@ -13,8 +13,10 @@
   2: tools/backend-credential-env, which the launcher calls to read Tofu state.
   3: desired state drops :domain and :package. The DNS zone is derived from the
      application hosts through utils/apps-domain, and :profile alone names the
-     stack."
-  3)
+     stack.
+  4: the yandex compute provider — the tofu/yandex template, the :yandex-*
+     desired-state keys, and :yc-token passed to tofu as YC_TOKEN."
+  4)
 
 (defn strip-ansi [s]
   (-> s

--- a/src/resources/io/github/bigconfig-ai/once/tools/ansible/library/once
+++ b/src/resources/io/github/bigconfig-ai/once/tools/ansible/library/once
@@ -12,6 +12,11 @@
 ;;; Reconciles the desired list of ONCE applications against `once list`.
 ;;; Deploys apps that are missing; removes apps that are no longer wanted.
 ;;;
+;;; Honors check mode: under `ansible-playbook --check` the only command
+;;; executed is `once list`; the diff is reported as would_deploy and
+;;; would_remove instead of being applied. Ansible does not skip WANT_JSON
+;;; modules in check mode, so the module has to enforce this itself.
+;;;
 ;;; Parameters (JSON args file):
 ;;;   applications  - required, list of app objects
 ;;;   namespace     - optional, default "once"
@@ -98,10 +103,10 @@
   (cond-> ["once" "-n" namespace "remove" host]
     remove-data? (conj "--remove-data")))
 
-(defn reconcile [applications namespace remove-data? teardown?]
+(defn reconcile [applications namespace remove-data? teardown? check-mode?]
   (when-not (seq applications)
     (fail-json "Missing required parameter: applications"))
-  (when teardown?
+  (when (and teardown? (not check-mode?))
     (run! (cond-> ["once" "-n" namespace "teardown"]
             remove-data? (conj "--remove-data"))))
   (let [apps-by-host  (reduce (fn [a e]
@@ -111,15 +116,25 @@
         list-out      (strip-ansi (:out (run! ["once" "-n" namespace "list"])))
         deployed      (parse-deployed-hosts list-out)
         to-deploy     (set/difference desired-hosts deployed)
-        to-remove     (set/difference deployed desired-hosts)]
-    (doseq [host to-remove]
-      (run! (build-remove-cmd namespace host remove-data?)))
-    (doseq [host to-deploy]
-      (let [app (apps-by-host host)]
-        (run! (build-deploy-cmd namespace app) (app-secrets app))))
-    (exit-json {:changed (boolean (or (seq to-deploy) (seq to-remove)))
-                :deployed (vec to-deploy)
-                :removed  (vec to-remove)})))
+        to-remove     (set/difference deployed desired-hosts)
+        changed?      (boolean (or (seq to-deploy) (seq to-remove)))
+        diff          {:before (str/join "\n" (sort deployed))
+                       :after  (str/join "\n" (sort desired-hosts))}]
+    (if check-mode?
+      (exit-json {:changed changed?
+                  :would_deploy (vec (sort to-deploy))
+                  :would_remove (vec (sort to-remove))
+                  :diff diff})
+      (do
+        (doseq [host to-remove]
+          (run! (build-remove-cmd namespace host remove-data?)))
+        (doseq [host to-deploy]
+          (let [app (apps-by-host host)]
+            (run! (build-deploy-cmd namespace app) (app-secrets app))))
+        (exit-json {:changed changed?
+                    :deployed (vec to-deploy)
+                    :removed  (vec to-remove)
+                    :diff diff})))))
 
 (defn -main [& args]
   (let [args-file (first args)]
@@ -129,11 +144,12 @@
                  (-> args-file slurp (json/parse-string true))
                  (catch Exception e
                    (fail-json (str "Failed to parse args file: " (.getMessage e)))))
-          {:keys [applications namespace remove-data teardown]
+          {:keys [applications namespace remove-data teardown _ansible_check_mode]
            :or   {namespace "once"
                   remove-data false
-                  teardown false}} args]
-      (reconcile applications namespace remove-data teardown))))
+                  teardown false
+                  _ansible_check_mode false}} args]
+      (reconcile applications namespace remove-data teardown _ansible_check_mode))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (apply -main *command-line-args*))
@@ -149,5 +165,5 @@
                              :image "ghcr.io/amiorin/big-config-website"}
                             {:host "www4.bigconfig.space"
                              :image "ghcr.io/amiorin/big-config-website"}]]
-          (reconcile applications "once" false true)))))
+          (reconcile applications "once" false true false)))))
   (-> tap-values))

--- a/src/resources/io/github/bigconfig-ai/once/tools/tofu/yandex/main.tf
+++ b/src/resources/io/github/bigconfig-ai/once/tools/tofu/yandex/main.tf
@@ -1,0 +1,84 @@
+# Tell terraform to use the provider and select a version.
+terraform {
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.130"
+    }
+  }
+}
+
+provider "yandex" {
+  # token comes from YC_TOKEN in the environment
+  cloud_id  = "<{ yandex-cloud-id }>"
+  folder_id = "<{ yandex-folder-id }>"
+  zone      = "<{ yandex-zone }>"
+}
+
+data "yandex_compute_image" "ubuntu" {
+  family = "<{ yandex-image-family }>"
+}
+
+resource "yandex_vpc_network" "network" {
+  name = "<{ yandex-name }>"
+}
+
+resource "yandex_vpc_subnet" "subnet" {
+  name           = "<{ yandex-name }>"
+  zone           = "<{ yandex-zone }>"
+  network_id     = yandex_vpc_network.network.id
+  v4_cidr_blocks = ["<{ yandex-subnet-cidr }>"]
+}
+
+resource "yandex_compute_instance" "node1" {
+  name        = "<{ yandex-name }>"
+  platform_id = "<{ yandex-platform-id }>"
+  zone        = "<{ yandex-zone }>"
+
+  resources {
+    cores         = <{ yandex-cores }>
+    memory        = <{ yandex-memory-gb }>
+    core_fraction = <{ yandex-core-fraction }>
+  }
+
+  boot_disk {
+    initialize_params {
+      image_id = data.yandex_compute_image.ubuntu.id
+      size     = <{ yandex-disk-size-gb }>
+    }
+  }
+
+  network_interface {
+    subnet_id = yandex_vpc_subnet.subnet.id
+    nat       = true
+  }
+
+  # Yandex has no account-level SSH key registry: the user and its key are
+  # created by cloud-init from instance metadata.
+  metadata = {
+    ssh-keys = "ubuntu:<{ compute-pubkey }>"
+  }
+
+  # Wait for ssh before starting Ansible
+  connection {
+    type = "ssh"
+    user = "ubuntu"
+    host = self.network_interface.0.nat_ip_address
+  }
+  provisioner "remote-exec" {
+    inline = ["ls"]
+  }
+  lifecycle {
+    prevent_destroy = <{ compute-prevent-destroy }>
+  }
+}
+
+output "params" {
+  value = {
+    ip = yandex_compute_instance.node1.network_interface.0.nat_ip_address
+    sudoer = "ubuntu"
+    uid = "1000"
+    name = "<{ profile }>"
+    user = "ubuntu"
+  }
+}

--- a/src/resources/io/github/bigconfig-ai/once/tools/tofu/yandex/main.tf
+++ b/src/resources/io/github/bigconfig-ai/once/tools/tofu/yandex/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     yandex = {
       source  = "yandex-cloud/yandex"
-      version = ">= 0.130"
+      version = ">= 0.120"
     }
   }
 }

--- a/test/clj/io/github/bigconfig_ai/once/once_module_test.clj
+++ b/test/clj/io/github/bigconfig_ai/once/once_module_test.clj
@@ -36,14 +36,18 @@
     (.setExecutable once true false)
     (.getAbsolutePath dir)))
 
-(defn- run-module
-  [app]
+(defn- run-module-args
+  [args]
   (let [dir (temp-dir!)
         shim (failing-deploy-shim! dir)
         args-file (io/file dir "args.json")]
-    (spit args-file (json/generate-string {:applications [app]}))
+    (spit args-file (json/generate-string args))
     (utils/shell-cmd ["bb" module (.getAbsolutePath args-file)]
                      {:extra-env {"PATH" (str shim ":" (System/getenv "PATH"))}})))
+
+(defn- run-module
+  [app]
+  (run-module-args {:applications [app]}))
 
 (deftest a-failed-deploy-reports-no-secrets
   (let [{:keys [exit out]} (run-module {:host "www.example.com"
@@ -70,3 +74,18 @@
     (testing "stderr from the failing command is scrubbed as well"
       (is (str/includes? (:msg result) "once deploy failed"))
       (is (str/includes? (:msg result) "***")))))
+
+(deftest check-mode-plans-without-deploying
+  ;; The shim's `deploy` fails loudly, so a zero exit proves check mode never
+  ;; ran it: `once list` is the only command a check run may execute.
+  (let [{:keys [exit out]} (run-module-args
+                            {:applications [{:host "www.example.com"
+                                             :image "ghcr.io/example/site:latest"}]
+                             :_ansible_check_mode true})
+        result (json/parse-string out true)]
+    (is (= 0 exit) "the failing deploy shim was never invoked")
+    (is (true? (:changed result)))
+    (is (= ["www.example.com"] (:would_deploy result)))
+    (is (= [] (:would_remove result)))
+    (is (= "" (get-in result [:diff :before])))
+    (is (= "www.example.com" (get-in result [:diff :after])))))


### PR DESCRIPTION
## What

Adds `yandex` as a fifth compute provider, following the existing per-provider conventions, plus check-mode support for the `once` Ansible module (needed so a CI "plan" can run `ansible-playbook --check` safely).

### Yandex Cloud compute provider

- **Template** `src/resources/.../tools/tofu/yandex/main.tf` — self-contained: creates a VPC network and subnet from `:yandex-subnet-cidr`, resolves the newest image of `:yandex-image-family`, and provisions the VM with a NAT'd public address. Yandex has no account-level SSH key registry, so `:compute-pubkey` (previously accepted but unused) is written into instance metadata as the `ubuntu` user's authorized key and becomes required for this provider only.
- **Launcher registries** — `compute-providers`, `compute-required`, `compute-secrets` (`:yc-token`).
- **Credential plumbing** — `:yc-token` reaches tofu as `YC_TOKEN` through the process environment, same path as `HCLOUD_TOKEN`; supplied via `GREEN_PAR_YC_TOKEN`.
- **Provider constraint** is `>= 0.120`: the OpenTofu registry mirror currently tops out at 0.127.0 for `yandex-cloud/yandex`, so a Terraform-registry-based `>= 0.130` could never resolve.
- **Contract bumped 3 → 4** (`utils/contract` + `launcher-contract`): a launcher pinned to an older once cannot render the new template or resolve the new keys.
- **All four desired-state surfaces updated** per CLAUDE.md: `green.edn`, `green-once/references/configuration.md`, `index.html`, plus README and the CLAUDE.md provider lists. (SKILL.md doesn't enumerate providers, so it needed no change.)

No new state backend: Yandex Object Storage is S3-compatible and already works through the `r2` backend with `:r2-endpoint "https://storage.yandexcloud.net"`; the docs mention this.

### Check mode for the `once` module

Ansible does **not** skip WANT_JSON modules under `--check` — the module received `_ansible_check_mode` but ignored it, so a check run deployed for real. Now:

- In check mode the only command executed is `once list`; the reconciliation is reported as `would_deploy` / `would_remove` instead of being applied (teardown is skipped too).
- The module returns a `diff` (before/after host lists) in both modes, so `--diff` renders nicely.
- New test `check-mode-plans-without-deploying`: the shim's `deploy` fails loudly, so a zero exit proves check mode never invoked it.

This makes "plan" pipelines possible: render with `green build`, then `tofu plan` per stage and `ansible-playbook --check --diff` against the rendered tree without touching anything.

## Also included

`fix: resolve green from its git pin in bb.edn` — the `:local/root "/home/ubuntu/code/green"` coordinate broke `bb` inside the repository on any machine but yours, including `deploy_test` and `once_module_test` (they run the bundled scripts with the repo as cwd). The local root is kept beside the pin in the same `#_#_` idiom `deps.edn` uses. Happy to drop this commit if you'd rather handle it differently.

## Not included

The launcher pin is untouched — `once-sha` still points at 03ac70a. After merging, `bb green pin` per the usual flow.

## Testing

- `clojure -M:test`: 30 tests, 128 assertions, 0 failures.
- **Verified against real Yandex Cloud**: a production create provisioned the VPC/subnet/VM (ru-central1-a, standard-v3), state on Yandex Object Storage via the `r2` backend, and ONCE serving a container over HTTPS with a Let's Encrypt cert. `describe` reports providers/SSH/apps correctly.
- **Check mode verified in CI**: `ansible-playbook --check --diff` over the rendered tree reports ok/changed=0 on a converged host (and `would_deploy` on drift) without side effects.
- One provider caveat worth knowing: `get.once.com` serves an HTML block page to RU-hosted VMs, so the "Install ONCE" task fails on Yandex until the installer is fetched elsewhere and pushed to the host (the task's `creates:` guard then skips it). Happy to discuss a fix (e.g., an overridable installer URL) in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)