### PR TITLE
feat: honor Ansible check mode in the once module

### DIFF
--- a/src/resources/io/github/bigconfig-ai/once/tools/ansible/library/once
+++ b/src/resources/io/github/bigconfig-ai/once/tools/ansible/library/once
@@ -12,6 +12,11 @@
 ;;; Reconciles the desired list of ONCE applications against `once list`.
 ;;; Deploys apps that are missing; removes apps that are no longer wanted.
 ;;;
+;;; Honors check mode: under `ansible-playbook --check` the only command
+;;; executed is `once list`; the reconciliation is reported as would_deploy and
+;;; would_remove instead of being applied. Ansible does not skip WANT_JSON
+;;; modules in check mode, so the module has to enforce this itself.
+;;;
 ;;; Parameters (JSON args file):
 ;;;   applications  - required, list of app objects
 ;;;   namespace     - optional, default "once"
@@ -98,10 +103,10 @@
   (cond-> ["once" "-n" namespace "remove" host]
     remove-data? (conj "--remove-data")))
 
-(defn reconcile [applications namespace remove-data? teardown?]
+(defn reconcile [applications namespace remove-data? teardown? check-mode?]
   (when-not (seq applications)
     (fail-json "Missing required parameter: applications"))
-  (when teardown?
+  (when (and teardown? (not check-mode?))
     (run! (cond-> ["once" "-n" namespace "teardown"]
             remove-data? (conj "--remove-data"))))
   (let [apps-by-host  (reduce (fn [a e]
@@ -111,15 +116,25 @@
         list-out      (strip-ansi (:out (run! ["once" "-n" namespace "list"])))
         deployed      (parse-deployed-hosts list-out)
         to-deploy     (set/difference desired-hosts deployed)
-        to-remove     (set/difference deployed desired-hosts)]
-    (doseq [host to-remove]
-      (run! (build-remove-cmd namespace host remove-data?)))
-    (doseq [host to-deploy]
-      (let [app (apps-by-host host)]
-        (run! (build-deploy-cmd namespace app) (app-secrets app))))
-    (exit-json {:changed (boolean (or (seq to-deploy) (seq to-remove)))
-                :deployed (vec to-deploy)
-                :removed  (vec to-remove)})))
+        to-remove     (set/difference deployed desired-hosts)
+        changed?      (boolean (or (seq to-deploy) (seq to-remove)))
+        diff          {:before (str/join "\n" (sort deployed))
+                       :after  (str/join "\n" (sort desired-hosts))}]
+    (if check-mode?
+      (exit-json {:changed changed?
+                  :would_deploy (vec (sort to-deploy))
+                  :would_remove (vec (sort to-remove))
+                  :diff diff})
+      (do
+        (doseq [host to-remove]
+          (run! (build-remove-cmd namespace host remove-data?)))
+        (doseq [host to-deploy]
+          (let [app (apps-by-host host)]
+            (run! (build-deploy-cmd namespace app) (app-secrets app))))
+        (exit-json {:changed changed?
+                    :deployed (vec to-deploy)
+                    :removed  (vec to-remove)
+                    :diff diff})))))
 
 (defn -main [& args]
   (let [args-file (first args)]
@@ -129,11 +144,13 @@
                  (-> args-file slurp (json/parse-string true))
                  (catch Exception e
                    (fail-json (str "Failed to parse args file: " (.getMessage e)))))
-          {:keys [applications namespace remove-data teardown]
+          {:keys [applications namespace remove-data teardown _ansible_check_mode]
            :or   {namespace "once"
                   remove-data false
-                  teardown false}} args]
-      (reconcile applications namespace remove-data teardown))))
+                  teardown false
+                  _ansible_check_mode false}} args]
+      (reconcile applications namespace remove-data teardown
+                 _ansible_check_mode))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (apply -main *command-line-args*))
@@ -149,5 +166,5 @@
                              :image "ghcr.io/amiorin/big-config-website"}
                             {:host "www4.bigconfig.space"
                              :image "ghcr.io/amiorin/big-config-website"}]]
-          (reconcile applications "once" false true)))))
+          (reconcile applications "once" false true false)))))
   (-> tap-values))

--- a/test/clj/io/github/bigconfig_ai/once/once_module_test.clj
+++ b/test/clj/io/github/bigconfig_ai/once/once_module_test.clj
@@ -36,14 +36,18 @@
     (.setExecutable once true false)
     (.getAbsolutePath dir)))
 
-(defn- run-module
-  [app]
+(defn- run-module-args
+  [args]
   (let [dir (temp-dir!)
         shim (failing-deploy-shim! dir)
         args-file (io/file dir "args.json")]
-    (spit args-file (json/generate-string {:applications [app]}))
+    (spit args-file (json/generate-string args))
     (process/run ["bb" module (.getAbsolutePath args-file)]
                  {:extra-env {"PATH" (str shim ":" (System/getenv "PATH"))}})))
+
+(defn- run-module
+  [app]
+  (run-module-args {:applications [app]}))
 
 (deftest a-failed-deploy-reports-no-secrets
   (let [{:keys [exit out]} (run-module {:host "www.example.com"
@@ -70,3 +74,18 @@
     (testing "stderr from the failing command is scrubbed as well"
       (is (str/includes? (:msg result) "once deploy failed"))
       (is (str/includes? (:msg result) "***")))))
+
+(deftest check-mode-plans-without-deploying
+  ;; The shim's `deploy` fails loudly, so a zero exit proves check mode never
+  ;; ran it: `once list` is the only command a check run may execute.
+  (let [{:keys [exit out]} (run-module-args
+                            {:applications [{:host "www.example.com"
+                                             :image "ghcr.io/example/site:latest"}]
+                             :_ansible_check_mode true})
+        result (json/parse-string out true)]
+    (is (= 0 exit) "the failing deploy shim was never invoked")
+    (is (true? (:changed result)))
+    (is (= ["www.example.com"] (:would_deploy result)))
+    (is (= [] (:would_remove result)))
+    (is (= "" (get-in result [:diff :before])))
+    (is (= "www.example.com" (get-in result [:diff :after])))))


### PR DESCRIPTION
Follow-up to #8 — thanks for landing the Yandex provider. This is the one piece from that branch that is independent of it, resubmitted on its own on top of current `green`.

## Problem

Ansible does **not** skip `WANT_JSON` modules under `--check`. The module received `_ansible_check_mode` in its args file and ignored it, so a check run reconciled for real — deploying and removing applications. Since `ansible-remote`'s other tasks are shell tasks with `creates:` guards (which Ansible does skip), `ansible-playbook --check` looks safe right up to the point where it mutates the host.

## Change

- In check mode the only command executed is `once list`; the reconciliation is reported as `would_deploy` / `would_remove` and teardown is skipped.
- Both modes now also return a before/after host `diff`, so `--diff` renders.
- New test `check-mode-plans-without-deploying` reuses the existing failing-deploy shim: since its `deploy` exits non-zero, a zero exit is proof that check mode never invoked it.

## Why it is useful

It makes a "plan" pipeline possible: `green build` to render, then `tofu plan` per stage plus `ansible-playbook --check --diff` over the rendered tree — a full read-only preview of both halves of a create. We run exactly that on every infrastructure change in CI, with the apply gated behind human approval.

## Testing

`clojure -M:test` — 56 tests, 270 assertions, 0 failures.

(Unrelated, so not included here: `bb.edn` still carries `:local/root "/home/ubuntu/code/green"`, which makes `bb` inside the repo fail on any other machine, including the two tests that shell out to `bb`. I carry a one-line fix locally — happy to send it separately if useful.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)