### PR TITLE
fix: a new image in the family should not plan a replacement of the server

### DIFF
--- a/green-once/references/configuration.md
+++ b/green-once/references/configuration.md
@@ -89,6 +89,8 @@ Required credential: `GREEN_PAR_HCLOUD_TOKEN`.
 
 Green creates a network, subnet, NAT-enabled instance, and boot disk. The public key is installed for the `ubuntu` user; keep its private half in `ssh-agent`. Required credential: `GREEN_PAR_YANDEX_TOKEN`, passed to OpenTofu as the provider-native `YC_TOKEN`.
 
+`:yandex-image-id` pins the boot image. Without it the image comes from `:yandex-image-family`, which resolves to whatever Yandex published most recently — and because a boot disk's image is immutable, an upstream release plans a replacement of the whole server. With `:compute-prevent-destroy` set (the default) that plan *fails* rather than warns, blocking unrelated deploys, so the family path ignores later changes to the image id. Pin the id to state which image the server actually runs; moving the pin then plans a replacement deliberately.
+
 ### Oracle Cloud Infrastructure
 
 ```clojure

--- a/green.edn
+++ b/green.edn
@@ -61,6 +61,9 @@
  :yandex-memory-gb 2
  :yandex-core-fraction 100
  :yandex-disk-size-gb 20
+ ;; Optional: pin the boot image so an upstream release cannot plan a
+ ;; replacement of the server. Unset means follow :yandex-image-family.
+ :yandex-image-id "REPLACE_ME"
 
  :oci-config-file-profile "REPLACE_ME"
  :oci-subnet-id "REPLACE_ME"

--- a/index.html
+++ b/index.html
@@ -902,8 +902,12 @@ done</code></pre>
 :yandex-cores 2
 :yandex-memory-gb 2
 :yandex-core-fraction 100
-:yandex-disk-size-gb 20</code></pre>
+:yandex-disk-size-gb 20
+;; Optional:
+:yandex-image-id "fd8..."</code></pre>
       <p>Creates a network, subnet, NAT-enabled Ubuntu instance, and boot disk. <code>:compute-pubkey</code> is installed for the <code>ubuntu</code> user; keep the private half in <code>ssh-agent</code>. Credential: <code>GREEN_PAR_YANDEX_TOKEN</code>, passed to OpenTofu as <code>YC_TOKEN</code>.</p>
+
+      <p><code>:yandex-image-id</code> pins the boot image. Without it the image is resolved from <code>:yandex-image-family</code>, which follows whatever Yandex published most recently; since a boot disk's image is immutable, an upstream release plans a replacement of the server — and with <code>:compute-prevent-destroy</code> set that plan fails rather than warns. The family path therefore ignores later image-id changes. Pin the id to state which image the server runs; moving the pin plans a replacement deliberately.</p>
 
       <h3>Oracle Cloud Infrastructure</h3>
       <pre><code class="language-clojure">:provider-compute "oci"

--- a/src/resources/io/github/bigconfig-ai/once/tools/tofu/yandex/main.tf
+++ b/src/resources/io/github/bigconfig-ai/once/tools/tofu/yandex/main.tf
@@ -15,9 +15,17 @@ provider "yandex" {
   zone      = "<{ yandex-zone }>"
 }
 
+<% if yandex-image-id %>
+# The image is pinned in desired state, so the server runs a known image and an
+# upstream release cannot move it.
+<% else %>
+# Resolved from the family, which is whatever Yandex has published most
+# recently. Convenient for a first install; see the lifecycle block below for
+# why it is then left alone.
 data "yandex_compute_image" "ubuntu" {
   family = "<{ yandex-image-family }>"
 }
+<% endif %>
 
 resource "yandex_vpc_network" "network" {
   name = "<{ yandex-name }>"
@@ -43,7 +51,11 @@ resource "yandex_compute_instance" "node1" {
 
   boot_disk {
     initialize_params {
+<% if yandex-image-id %>
+      image_id = "<{ yandex-image-id }>"
+<% else %>
       image_id = data.yandex_compute_image.ubuntu.id
+<% endif %>
       size     = <{ yandex-disk-size-gb }>
     }
   }
@@ -70,6 +82,18 @@ resource "yandex_compute_instance" "node1" {
   }
   lifecycle {
     prevent_destroy = <{ compute-prevent-destroy }>
+<% if yandex-image-id %>
+    # No ignore_changes here on purpose: with the image pinned, changing
+    # :yandex-image-id *should* plan a replacement, and prevent_destroy makes
+    # that a deliberate decision rather than a surprise.
+<% else %>
+    # A boot disk's image is immutable, so tracking a family plans a
+    # replacement of the whole server every time Yandex publishes a release —
+    # and with prevent_destroy set the plan fails rather than warns, blocking
+    # unrelated deploys. Keep the disk; update the OS in place. Pin
+    # :yandex-image-id to state which image the server runs.
+    ignore_changes = [boot_disk[0].initialize_params[0].image_id]
+<% endif %>
   }
 }
 

--- a/test/clj/io/github/bigconfig_ai/once/tools_test.clj
+++ b/test/clj/io/github/bigconfig_ai/once/tools_test.clj
@@ -71,7 +71,47 @@
         (is (str/includes? main "cloud_id  = \"cloud-id\""))
         (is (str/includes? main
                            "ssh-keys = \"ubuntu:ssh-ed25519 AAAATEST operator\""))
-        (is (not (str/includes? main "a-real-yandex-token"))))
+        (is (not (str/includes? main "a-real-yandex-token")))
+        (testing "the family is followed, but its id is then left alone"
+          (is (str/includes? main "data \"yandex_compute_image\""))
+          (is (str/includes?
+               main
+               "ignore_changes = [boot_disk[0].initialize_params[0].image_id]"))))
+      (finally
+        (delete-tree! workdir)))))
+
+(deftest yandex-pins-the-image-when-one-is-named
+  (let [workdir (temp-dir)
+        opts {:workdir workdir
+              :profile "test"
+              :green/event :build
+              :provider-compute "yandex"
+              :provider-backend "local"
+              :compute-prevent-destroy true
+              :compute-pubkey "ssh-ed25519 AAAATEST operator"
+              :yandex-cloud-id "cloud-id"
+              :yandex-folder-id "folder-id"
+              :yandex-zone "ru-central1-a"
+              :yandex-image-family "ubuntu-2404-lts"
+              :yandex-image-id "fd8someimageid"
+              :yandex-name "once-test"
+              :yandex-subnet-cidr "10.0.0.0/24"
+              :yandex-platform-id "standard-v3"
+              :yandex-cores 2
+              :yandex-memory-gb 2
+              :yandex-core-fraction 100
+              :yandex-disk-size-gb 20}]
+    (try
+      (let [result (tools/tofu-compute-step opts)
+            main (slurp (io/file (tools/tool-dir opts "tofu-compute") "main.tf"))]
+        (is (zero? (:green/exit result)))
+        (is (str/includes? main "image_id = \"fd8someimageid\""))
+        (testing "the family lookup is gone, so nothing can move the image"
+          (is (not (str/includes? main "data \"yandex_compute_image\""))))
+        (testing "and moving the pin is allowed to plan a replacement"
+          ;; the directive, not the word: a comment above it explains why there
+          ;; is none
+          (is (not (str/includes? main "ignore_changes = [")))))
       (finally
         (delete-tree! workdir)))))
 


### PR DESCRIPTION
## The problem

The yandex template resolves the boot image from a family:

```hcl
data "yandex_compute_image" "ubuntu" { family = "<{ yandex-image-family }>" }
…
image_id = data.yandex_compute_image.ubuntu.id
```

A family returns whatever Yandex has published most recently, and a boot disk's image is immutable — so the day Canonical publishes a new `ubuntu-2404-lts`, OpenTofu plans to **destroy and recreate the server**. With `:compute-prevent-destroy true` (the default) that plan does not warn, it **fails**:

```
Plan: 1 to add, 0 to change, 1 to destroy.
│ Error: Instance cannot be destroyed
│ Resource yandex_compute_instance.node1 has prevent_destroy set, but the plan calls for it to be destroyed.
      ~ image_id = "fd8fvfgir27tr63rk9s9" -> "fd83ergat2e815oohe7o" # forces replacement
```

Not hypothetical: this hit us two days after provisioning, on an unrelated application change, and every deploy stayed blocked until the cause was found.

## The change

- **The family path stops tracking the image id** — `ignore_changes` on `boot_disk[0].initialize_params[0].image_id`. A single-server install keeps its disk and updates the OS in place; adopting a new base image is a rebuild, not a side effect of someone else's release.
- **A new optional `:yandex-image-id`** is the honest fix: desired state names the image, the family data source is not rendered at all, and `ignore_changes` is deliberately absent — so moving the pin *does* plan a replacement, which `prevent_destroy` turns into a decision rather than a surprise.

Absent the key, rendering is unchanged apart from `ignore_changes`. Documented on all three desired-state surfaces: `green.edn`, `green-once/references/configuration.md`, `index.html`.

## Testing

`clojure -M:test` — 56 tests, 270 assertions, 0 failures. The existing yandex test now also asserts the family data source and the ignore; a new test covers the pinned path (image id rendered, family lookup absent, no `ignore_changes`).

Verified in production on Yandex Cloud: with the image pinned the plan is clean again and the previously blocked deploy went through.

## One note

**OCI looks to have the same shape** — `data "oci_core_images"` sorted by `TIMECREATED` feeding `source_id`, so a new Oracle image should plan a replacement the same way. I have not touched it and cannot test against OCI, so I am only flagging it. DigitalOcean and Hetzner are unaffected: they take stable image slugs rather than resolving an id.

Independent of #10, though both touch the instance's `lifecycle` block, so whichever lands second will want a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)