### PR TITLE
feat: honor Ansible check mode in the once module

### DIFF
--- a/blue/src/package_once_blue/resources/tools/ansible/library/once
+++ b/blue/src/package_once_blue/resources/tools/ansible/library/once
@@ -12,6 +12,11 @@
 ;;; Reconciles the desired list of ONCE applications against `once list`.
 ;;; Deploys apps that are missing; removes apps that are no longer wanted.
 ;;;
+;;; Honors check mode: under `ansible-playbook --check` the only command
+;;; executed is `once list`; the reconciliation is reported as would_deploy and
+;;; would_remove instead of being applied. Ansible does not skip WANT_JSON
+;;; modules in check mode, so the module has to enforce this itself.
+;;;
 ;;; Parameters (JSON args file):
 ;;;   applications  - required, list of app objects
 ;;;   namespace     - optional, default "once"
@@ -98,10 +103,10 @@
   (cond-> ["once" "-n" namespace "remove" host]
     remove-data? (conj "--remove-data")))
 
-(defn reconcile [applications namespace remove-data? teardown?]
+(defn reconcile [applications namespace remove-data? teardown? check-mode?]
   (when-not (seq applications)
     (fail-json "Missing required parameter: applications"))
-  (when teardown?
+  (when (and teardown? (not check-mode?))
     (run! (cond-> ["once" "-n" namespace "teardown"]
             remove-data? (conj "--remove-data"))))
   (let [apps-by-host  (reduce (fn [a e]
@@ -111,15 +116,25 @@
         list-out      (strip-ansi (:out (run! ["once" "-n" namespace "list"])))
         deployed      (parse-deployed-hosts list-out)
         to-deploy     (set/difference desired-hosts deployed)
-        to-remove     (set/difference deployed desired-hosts)]
-    (doseq [host to-remove]
-      (run! (build-remove-cmd namespace host remove-data?)))
-    (doseq [host to-deploy]
-      (let [app (apps-by-host host)]
-        (run! (build-deploy-cmd namespace app) (app-secrets app))))
-    (exit-json {:changed (boolean (or (seq to-deploy) (seq to-remove)))
-                :deployed (vec to-deploy)
-                :removed  (vec to-remove)})))
+        to-remove     (set/difference deployed desired-hosts)
+        changed?      (boolean (or (seq to-deploy) (seq to-remove)))
+        diff          {:before (str/join "\n" (sort deployed))
+                       :after  (str/join "\n" (sort desired-hosts))}]
+    (if check-mode?
+      (exit-json {:changed changed?
+                  :would_deploy (vec (sort to-deploy))
+                  :would_remove (vec (sort to-remove))
+                  :diff diff})
+      (do
+        (doseq [host to-remove]
+          (run! (build-remove-cmd namespace host remove-data?)))
+        (doseq [host to-deploy]
+          (let [app (apps-by-host host)]
+            (run! (build-deploy-cmd namespace app) (app-secrets app))))
+        (exit-json {:changed changed?
+                    :deployed (vec to-deploy)
+                    :removed  (vec to-remove)
+                    :diff diff})))))
 
 (defn -main [& args]
   (let [args-file (first args)]
@@ -129,11 +144,13 @@
                  (-> args-file slurp (json/parse-string true))
                  (catch Exception e
                    (fail-json (str "Failed to parse args file: " (.getMessage e)))))
-          {:keys [applications namespace remove-data teardown]
+          {:keys [applications namespace remove-data teardown _ansible_check_mode]
            :or   {namespace "once"
                   remove-data false
-                  teardown false}} args]
-      (reconcile applications namespace remove-data teardown))))
+                  teardown false
+                  _ansible_check_mode false}} args]
+      (reconcile applications namespace remove-data teardown
+                 _ansible_check_mode))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (apply -main *command-line-args*))
@@ -149,5 +166,5 @@
                              :image "ghcr.io/amiorin/big-config-website"}
                             {:host "www4.bigconfig.space"
                              :image "ghcr.io/amiorin/big-config-website"}]]
-          (reconcile applications "once" false true)))))
+          (reconcile applications "once" false true false)))))
   (-> tap-values))

--- a/green/src/resources/io/github/getcolors/once/tools/ansible/library/once
+++ b/green/src/resources/io/github/getcolors/once/tools/ansible/library/once
@@ -12,6 +12,11 @@
 ;;; Reconciles the desired list of ONCE applications against `once list`.
 ;;; Deploys apps that are missing; removes apps that are no longer wanted.
 ;;;
+;;; Honors check mode: under `ansible-playbook --check` the only command
+;;; executed is `once list`; the reconciliation is reported as would_deploy and
+;;; would_remove instead of being applied. Ansible does not skip WANT_JSON
+;;; modules in check mode, so the module has to enforce this itself.
+;;;
 ;;; Parameters (JSON args file):
 ;;;   applications  - required, list of app objects
 ;;;   namespace     - optional, default "once"
@@ -98,10 +103,10 @@
   (cond-> ["once" "-n" namespace "remove" host]
     remove-data? (conj "--remove-data")))
 
-(defn reconcile [applications namespace remove-data? teardown?]
+(defn reconcile [applications namespace remove-data? teardown? check-mode?]
   (when-not (seq applications)
     (fail-json "Missing required parameter: applications"))
-  (when teardown?
+  (when (and teardown? (not check-mode?))
     (run! (cond-> ["once" "-n" namespace "teardown"]
             remove-data? (conj "--remove-data"))))
   (let [apps-by-host  (reduce (fn [a e]
@@ -111,15 +116,25 @@
         list-out      (strip-ansi (:out (run! ["once" "-n" namespace "list"])))
         deployed      (parse-deployed-hosts list-out)
         to-deploy     (set/difference desired-hosts deployed)
-        to-remove     (set/difference deployed desired-hosts)]
-    (doseq [host to-remove]
-      (run! (build-remove-cmd namespace host remove-data?)))
-    (doseq [host to-deploy]
-      (let [app (apps-by-host host)]
-        (run! (build-deploy-cmd namespace app) (app-secrets app))))
-    (exit-json {:changed (boolean (or (seq to-deploy) (seq to-remove)))
-                :deployed (vec to-deploy)
-                :removed  (vec to-remove)})))
+        to-remove     (set/difference deployed desired-hosts)
+        changed?      (boolean (or (seq to-deploy) (seq to-remove)))
+        diff          {:before (str/join "\n" (sort deployed))
+                       :after  (str/join "\n" (sort desired-hosts))}]
+    (if check-mode?
+      (exit-json {:changed changed?
+                  :would_deploy (vec (sort to-deploy))
+                  :would_remove (vec (sort to-remove))
+                  :diff diff})
+      (do
+        (doseq [host to-remove]
+          (run! (build-remove-cmd namespace host remove-data?)))
+        (doseq [host to-deploy]
+          (let [app (apps-by-host host)]
+            (run! (build-deploy-cmd namespace app) (app-secrets app))))
+        (exit-json {:changed changed?
+                    :deployed (vec to-deploy)
+                    :removed  (vec to-remove)
+                    :diff diff})))))
 
 (defn -main [& args]
   (let [args-file (first args)]
@@ -129,11 +144,13 @@
                  (-> args-file slurp (json/parse-string true))
                  (catch Exception e
                    (fail-json (str "Failed to parse args file: " (.getMessage e)))))
-          {:keys [applications namespace remove-data teardown]
+          {:keys [applications namespace remove-data teardown _ansible_check_mode]
            :or   {namespace "once"
                   remove-data false
-                  teardown false}} args]
-      (reconcile applications namespace remove-data teardown))))
+                  teardown false
+                  _ansible_check_mode false}} args]
+      (reconcile applications namespace remove-data teardown
+                 _ansible_check_mode))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (apply -main *command-line-args*))
@@ -149,5 +166,5 @@
                              :image "ghcr.io/amiorin/big-config-website"}
                             {:host "www4.bigconfig.space"
                              :image "ghcr.io/amiorin/big-config-website"}]]
-          (reconcile applications "once" false true)))))
+          (reconcile applications "once" false true false)))))
   (-> tap-values))

--- a/green/test/clj/io/github/getcolors/once/once_module_test.clj
+++ b/green/test/clj/io/github/getcolors/once/once_module_test.clj
@@ -36,14 +36,18 @@
     (.setExecutable once true false)
     (.getAbsolutePath dir)))
 
-(defn- run-module
-  [app]
+(defn- run-module-args
+  [args]
   (let [dir (temp-dir!)
         shim (failing-deploy-shim! dir)
         args-file (io/file dir "args.json")]
-    (spit args-file (json/generate-string {:applications [app]}))
+    (spit args-file (json/generate-string args))
     (process/run ["bb" module (.getAbsolutePath args-file)]
                  {:extra-env {"PATH" (str shim ":" (System/getenv "PATH"))}})))
+
+(defn- run-module
+  [app]
+  (run-module-args {:applications [app]}))
 
 (deftest a-failed-deploy-reports-no-secrets
   (let [{:keys [exit out]} (run-module {:host "www.example.com"
@@ -70,3 +74,18 @@
     (testing "stderr from the failing command is scrubbed as well"
       (is (str/includes? (:msg result) "once deploy failed"))
       (is (str/includes? (:msg result) "***")))))
+
+(deftest check-mode-plans-without-deploying
+  ;; The shim's `deploy` fails loudly, so a zero exit proves check mode never
+  ;; ran it: `once list` is the only command a check run may execute.
+  (let [{:keys [exit out]} (run-module-args
+                            {:applications [{:host "www.example.com"
+                                             :image "ghcr.io/example/site:latest"}]
+                             :_ansible_check_mode true})
+        result (json/parse-string out true)]
+    (is (= 0 exit) "the failing deploy shim was never invoked")
+    (is (true? (:changed result)))
+    (is (= ["www.example.com"] (:would_deploy result)))
+    (is (= [] (:would_remove result)))
+    (is (= "" (get-in result [:diff :before])))
+    (is (= "www.example.com" (get-in result [:diff :after])))))

--- a/red/resources/tools/ansible/library/once
+++ b/red/resources/tools/ansible/library/once
@@ -12,6 +12,11 @@
 ;;; Reconciles the desired list of ONCE applications against `once list`.
 ;;; Deploys apps that are missing; removes apps that are no longer wanted.
 ;;;
+;;; Honors check mode: under `ansible-playbook --check` the only command
+;;; executed is `once list`; the reconciliation is reported as would_deploy and
+;;; would_remove instead of being applied. Ansible does not skip WANT_JSON
+;;; modules in check mode, so the module has to enforce this itself.
+;;;
 ;;; Parameters (JSON args file):
 ;;;   applications  - required, list of app objects
 ;;;   namespace     - optional, default "once"
@@ -98,10 +103,10 @@
   (cond-> ["once" "-n" namespace "remove" host]
     remove-data? (conj "--remove-data")))
 
-(defn reconcile [applications namespace remove-data? teardown?]
+(defn reconcile [applications namespace remove-data? teardown? check-mode?]
   (when-not (seq applications)
     (fail-json "Missing required parameter: applications"))
-  (when teardown?
+  (when (and teardown? (not check-mode?))
     (run! (cond-> ["once" "-n" namespace "teardown"]
             remove-data? (conj "--remove-data"))))
   (let [apps-by-host  (reduce (fn [a e]
@@ -111,15 +116,25 @@
         list-out      (strip-ansi (:out (run! ["once" "-n" namespace "list"])))
         deployed      (parse-deployed-hosts list-out)
         to-deploy     (set/difference desired-hosts deployed)
-        to-remove     (set/difference deployed desired-hosts)]
-    (doseq [host to-remove]
-      (run! (build-remove-cmd namespace host remove-data?)))
-    (doseq [host to-deploy]
-      (let [app (apps-by-host host)]
-        (run! (build-deploy-cmd namespace app) (app-secrets app))))
-    (exit-json {:changed (boolean (or (seq to-deploy) (seq to-remove)))
-                :deployed (vec to-deploy)
-                :removed  (vec to-remove)})))
+        to-remove     (set/difference deployed desired-hosts)
+        changed?      (boolean (or (seq to-deploy) (seq to-remove)))
+        diff          {:before (str/join "\n" (sort deployed))
+                       :after  (str/join "\n" (sort desired-hosts))}]
+    (if check-mode?
+      (exit-json {:changed changed?
+                  :would_deploy (vec (sort to-deploy))
+                  :would_remove (vec (sort to-remove))
+                  :diff diff})
+      (do
+        (doseq [host to-remove]
+          (run! (build-remove-cmd namespace host remove-data?)))
+        (doseq [host to-deploy]
+          (let [app (apps-by-host host)]
+            (run! (build-deploy-cmd namespace app) (app-secrets app))))
+        (exit-json {:changed changed?
+                    :deployed (vec to-deploy)
+                    :removed  (vec to-remove)
+                    :diff diff})))))
 
 (defn -main [& args]
   (let [args-file (first args)]
@@ -129,11 +144,13 @@
                  (-> args-file slurp (json/parse-string true))
                  (catch Exception e
                    (fail-json (str "Failed to parse args file: " (.getMessage e)))))
-          {:keys [applications namespace remove-data teardown]
+          {:keys [applications namespace remove-data teardown _ansible_check_mode]
            :or   {namespace "once"
                   remove-data false
-                  teardown false}} args]
-      (reconcile applications namespace remove-data teardown))))
+                  teardown false
+                  _ansible_check_mode false}} args]
+      (reconcile applications namespace remove-data teardown
+                 _ansible_check_mode))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (apply -main *command-line-args*))
@@ -149,5 +166,5 @@
                              :image "ghcr.io/amiorin/big-config-website"}
                             {:host "www4.bigconfig.space"
                              :image "ghcr.io/amiorin/big-config-website"}]]
-          (reconcile applications "once" false true)))))
+          (reconcile applications "once" false true false)))))
   (-> tap-values))


### PR DESCRIPTION
Ansible does not skip WANT_JSON modules under --check, so the module has to enforce check mode itself: it reads _ansible_check_mode from the args file, and when set runs only `once list`, reporting the reconciliation as would_deploy and would_remove instead of applying it. Both modes now also return a diff (deployed hosts before, desired hosts after) so --diff shows what a run would change.

The module is a shared resource, so the same bytes land in green, red, and blue; the green suite gains a test that proves a check run never invokes the failing deploy shim.