### PR TITLE
feat: optional reserved public address for yandex compute

### DIFF
--- a/blue/src/package_once_blue/resources/tools/tofu/yandex/main.tf
+++ b/blue/src/package_once_blue/resources/tools/tofu/yandex/main.tf
@@ -29,7 +29,19 @@ resource "yandex_vpc_subnet" "subnet" {
   network_id     = yandex_vpc_network.network.id
   v4_cidr_blocks = ["<{ yandex-subnet-cidr }>"]
 }
+<% if yandex-static-ip %>
+# Yandex assigns an ephemeral public address when NAT is enabled, and releases
+# it whenever the instance stops — a restart comes back on a different IP. A
+# reserved address survives stop/start, so DNS records and certificates bound
+# to the host stay valid.
+resource "yandex_vpc_address" "addr" {
+  name = "<{ yandex-name }>"
 
+  external_ipv4_address {
+    zone_id = "<{ yandex-zone }>"
+  }
+}
+<% endif %>
 resource "yandex_compute_instance" "node1" {
   name        = "<{ yandex-name }>"
   platform_id = "<{ yandex-platform-id }>"
@@ -51,8 +63,14 @@ resource "yandex_compute_instance" "node1" {
   network_interface {
     subnet_id = yandex_vpc_subnet.subnet.id
     nat       = true
-  }
-
+<% if yandex-static-ip %>    nat_ip_address = yandex_vpc_address.addr.external_ipv4_address[0].address
+<% endif %>  }
+<% if yandex-allow-stopping-for-update %>
+  # Yandex cannot change some attributes — the NAT address among them — while
+  # the instance runs. Opt in so tofu may stop it briefly to apply such a
+  # change instead of failing the apply.
+  allow_stopping_for_update = true
+<% endif %>
   # Yandex has no account-level SSH key registry: the user and its key are
   # created by cloud-init from instance metadata.
   metadata = {

--- a/colors.yml
+++ b/colors.yml
@@ -108,6 +108,12 @@ yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
 yandex-disk-size-gb: 20
+# Optional. A reserved address survives stop/start, where the ephemeral NAT
+# address Yandex hands out is released when the instance stops. Stopping for
+# update is off so an apply that Yandex cannot perform in place (cores,
+# memory, platform) fails instead of taking the instance down.
+yandex-static-ip: false
+yandex-allow-stopping-for-update: false
 
 oci-config-file-profile: REPLACE_ME
 oci-subnet-id: REPLACE_ME

--- a/green/src/clj/io/github/getcolors/once/utils.clj
+++ b/green/src/clj/io/github/getcolors/once/utils.clj
@@ -41,8 +41,13 @@
      getcolors org. The launcher resolves these names directly, so one pinned
      older cannot find them. The rename also changes generated Terraform
      resource addresses, which existing stacks must migrate with
-     `tofu state mv` before their next apply -- see README.md."
-  10)
+     `tofu state mv` before their next apply -- see README.md.
+  11: :yandex-static-ip reserves a public address the instance's NAT is pinned
+     to, and :yandex-allow-stopping-for-update lets tofu stop the instance for
+     changes Yandex cannot apply in place. A launcher pinned older renders
+     neither key and ignores both silently, so the server keeps its ephemeral
+     address and loses it on the next stop."
+  11)
 
 (defn registrable-domain
   "The DNS zone `host` belongs to: its last two labels. Multi-label suffixes

--- a/green/src/resources/io/github/getcolors/once/tools/tofu/yandex/main.tf
+++ b/green/src/resources/io/github/getcolors/once/tools/tofu/yandex/main.tf
@@ -29,7 +29,19 @@ resource "yandex_vpc_subnet" "subnet" {
   network_id     = yandex_vpc_network.network.id
   v4_cidr_blocks = ["<{ yandex-subnet-cidr }>"]
 }
+<% if yandex-static-ip %>
+# Yandex assigns an ephemeral public address when NAT is enabled, and releases
+# it whenever the instance stops — a restart comes back on a different IP. A
+# reserved address survives stop/start, so DNS records and certificates bound
+# to the host stay valid.
+resource "yandex_vpc_address" "addr" {
+  name = "<{ yandex-name }>"
 
+  external_ipv4_address {
+    zone_id = "<{ yandex-zone }>"
+  }
+}
+<% endif %>
 resource "yandex_compute_instance" "node1" {
   name        = "<{ yandex-name }>"
   platform_id = "<{ yandex-platform-id }>"
@@ -51,8 +63,14 @@ resource "yandex_compute_instance" "node1" {
   network_interface {
     subnet_id = yandex_vpc_subnet.subnet.id
     nat       = true
-  }
-
+<% if yandex-static-ip %>    nat_ip_address = yandex_vpc_address.addr.external_ipv4_address[0].address
+<% endif %>  }
+<% if yandex-allow-stopping-for-update %>
+  # Yandex cannot change some attributes — the NAT address among them — while
+  # the instance runs. Opt in so tofu may stop it briefly to apply such a
+  # change instead of failing the apply.
+  allow_stopping_for_update = true
+<% endif %>
   # Yandex has no account-level SSH key registry: the user and its key are
   # created by cloud-init from instance metadata.
   metadata = {

--- a/green/test/clj/io/github/getcolors/once/tools_test.clj
+++ b/green/test/clj/io/github/getcolors/once/tools_test.clj
@@ -71,7 +71,50 @@
         (is (str/includes? main "cloud_id  = \"cloud-id\""))
         (is (str/includes? main
                            "ssh-keys = \"ubuntu:ssh-ed25519 AAAATEST operator\""))
-        (is (not (str/includes? main "a-real-yandex-token"))))
+        (is (not (str/includes? main "a-real-yandex-token")))
+        (testing "an ephemeral address unless one is reserved"
+          ;; the output block always reads the instance's nat_ip_address, so
+          ;; look for the reserved-address resource and the assignment to it
+          (is (not (str/includes? main "yandex_vpc_address")))
+          (is (not (str/includes? main "nat_ip_address =")))
+          (is (not (str/includes? main "allow_stopping_for_update")))))
+      (finally
+        (delete-tree! workdir)))))
+
+(deftest yandex-reserves-an-address-when-asked
+  (let [workdir (temp-dir)
+        opts {:workdir workdir
+              :profile "test"
+              :green/event :build
+              :provider-compute "yandex"
+              :provider-backend "local"
+              :compute-prevent-destroy true
+              :compute-pubkey "ssh-ed25519 AAAATEST operator"
+              :yandex-cloud-id "cloud-id"
+              :yandex-folder-id "folder-id"
+              :yandex-zone "ru-central1-a"
+              :yandex-image-family "ubuntu-2404-lts"
+              :yandex-name "once-test"
+              :yandex-subnet-cidr "10.0.0.0/24"
+              :yandex-platform-id "standard-v3"
+              :yandex-cores 2
+              :yandex-memory-gb 2
+              :yandex-core-fraction 100
+              :yandex-disk-size-gb 20
+              :yandex-static-ip true
+              :yandex-allow-stopping-for-update true}]
+    (try
+      (let [result (tools/tofu-compute-step opts)
+            main (slurp (io/file (tools/tool-dir opts "tofu-compute") "main.tf"))]
+        (is (zero? (:green/exit result)))
+        (is (str/includes? main "resource \"yandex_vpc_address\" \"addr\""))
+        (is (str/includes? main "zone_id = \"ru-central1-a\""))
+        (testing "the instance is pinned to the reserved address"
+          (is (str/includes?
+               main
+               "nat_ip_address = yandex_vpc_address.addr.external_ipv4_address[0].address")))
+        (testing "and tofu may stop the instance to attach it"
+          (is (str/includes? main "allow_stopping_for_update = true"))))
       (finally
         (delete-tree! workdir)))))
 

--- a/index.html
+++ b/index.html
@@ -961,8 +961,12 @@ yandex-platform-id: standard-v3
 yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
-yandex-disk-size-gb: 20</code></pre>
+yandex-disk-size-gb: 20
+yandex-static-ip: false
+yandex-allow-stopping-for-update: false</code></pre>
       <p>Creates a network, subnet, NAT-enabled Ubuntu instance, and boot disk. <code>compute-pubkey</code> is installed for the <code>ubuntu</code> user; keep the private half in <code>ssh-agent</code>. Credential: <code>COLORS_PAR_YANDEX_TOKEN</code>, passed to OpenTofu as <code>YC_TOKEN</code>.</p>
+      <p><code>yandex-static-ip</code> reserves a <code>yandex_vpc_address</code> and pins the instance's NAT to it. Yandex releases an ephemeral NAT address whenever an instance stops, so without a reserved address a restarted instance comes back on a different IP and anything bound to the old one — a DNS record, a certificate, an <code>~/.ssh/config</code> entry — silently breaks.</p>
+      <p><code>yandex-allow-stopping-for-update</code> lets OpenTofu stop the instance to apply a change Yandex cannot make in place, such as <code>yandex-cores</code>, <code>yandex-memory-gb</code>, or <code>yandex-platform-id</code>. Leave it off for a server carrying traffic — the apply then fails naming the flag rather than taking the instance down mid-deploy — and enable it for the one deploy that resizes the instance (<code>COLORS_PAR_YANDEX_ALLOW_STOPPING_FOR_UPDATE=true</code>). Attaching a reserved address does not need it. Both keys default to <code>false</code>, which renders exactly as before.</p>
 
       <h3>Oracle Cloud Infrastructure</h3>
       <pre><code class="language-yaml">provider-compute: oci

--- a/red/resources/tools/tofu/yandex/main.tf
+++ b/red/resources/tools/tofu/yandex/main.tf
@@ -29,7 +29,19 @@ resource "yandex_vpc_subnet" "subnet" {
   network_id     = yandex_vpc_network.network.id
   v4_cidr_blocks = ["<{ yandex-subnet-cidr }>"]
 }
+<% if yandex-static-ip %>
+# Yandex assigns an ephemeral public address when NAT is enabled, and releases
+# it whenever the instance stops — a restart comes back on a different IP. A
+# reserved address survives stop/start, so DNS records and certificates bound
+# to the host stay valid.
+resource "yandex_vpc_address" "addr" {
+  name = "<{ yandex-name }>"
 
+  external_ipv4_address {
+    zone_id = "<{ yandex-zone }>"
+  }
+}
+<% endif %>
 resource "yandex_compute_instance" "node1" {
   name        = "<{ yandex-name }>"
   platform_id = "<{ yandex-platform-id }>"
@@ -51,8 +63,14 @@ resource "yandex_compute_instance" "node1" {
   network_interface {
     subnet_id = yandex_vpc_subnet.subnet.id
     nat       = true
-  }
-
+<% if yandex-static-ip %>    nat_ip_address = yandex_vpc_address.addr.external_ipv4_address[0].address
+<% endif %>  }
+<% if yandex-allow-stopping-for-update %>
+  # Yandex cannot change some attributes — the NAT address among them — while
+  # the instance runs. Opt in so tofu may stop it briefly to apply such a
+  # change instead of failing the apply.
+  allow_stopping_for_update = true
+<% endif %>
   # Yandex has no account-level SSH key registry: the user and its key are
   # created by cloud-init from instance metadata.
   metadata = {

--- a/scripts/parity.sh
+++ b/scripts/parity.sh
@@ -36,6 +36,12 @@ build_variant google COLORS_PAR_PROVIDER_COMPUTE=google
 build_variant digitalocean-vpc COLORS_PAR_DIGITALOCEAN_VPC_UUID=vpc-123
 build_variant hcloud COLORS_PAR_PROVIDER_COMPUTE=hcloud
 build_variant yandex COLORS_PAR_PROVIDER_COMPUTE=yandex
+# Both toggles of the reserved-address branch. The fixture carries the keys as
+# booleans so these overrides are coerced to boolean true — the three template
+# engines agree on boolean truthiness, not on the string "false".
+build_variant yandex-static COLORS_PAR_PROVIDER_COMPUTE=yandex \
+  COLORS_PAR_YANDEX_STATIC_IP=true \
+  COLORS_PAR_YANDEX_ALLOW_STOPPING_FOR_UPDATE=true
 build_variant oci COLORS_PAR_PROVIDER_COMPUTE=oci
 # Both sides of the oci-image-id branch. The unpinned side renders a data
 # source and the pinned side renders none, so a colour whose template engine

--- a/skills/package-once-green/green
+++ b/skills/package-once-green/green
@@ -35,7 +35,7 @@
   "Minimum io.github.getcolors/once contract this launcher requires.
   Guarded at run time so a stale pin fails loudly instead of rendering
   templates from an older commit."
-  10)
+  11)
 
 ;; Managed by `bb pin` — do not edit by hand.
 (def ^:private once-sha "adeb1f7738a11293bdde6343b16fddbfe92bb2ae")

--- a/skills/package-once-green/references/configuration.md
+++ b/skills/package-once-green/references/configuration.md
@@ -162,9 +162,18 @@ yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
 yandex-disk-size-gb: 20
+# Optional:
+yandex-static-ip: false
+yandex-allow-stopping-for-update: false
 ```
 
 Green creates a network, subnet, NAT-enabled instance, and boot disk. The public key is installed for the `ubuntu` user; keep its private half in `ssh-agent`. Required credential: `COLORS_PAR_YANDEX_TOKEN`, passed to OpenTofu as the provider-native `YC_TOKEN`.
+
+`:yandex-static-ip` reserves a `yandex_vpc_address` and pins the instance's NAT to it. Yandex releases an ephemeral NAT address whenever an instance stops, so without a reserved address a restarted instance returns on a different IP and anything bound to the old one — a DNS record, a certificate, an `~/.ssh/config` entry — silently breaks.
+
+`:yandex-allow-stopping-for-update` lets OpenTofu stop the instance to apply a change Yandex cannot make in place, such as `:yandex-cores`, `:yandex-memory-gb`, or `:yandex-platform-id`. Leave it off for a server that carries traffic: the apply then fails naming the flag instead of taking the instance down mid-deploy, and it can be enabled for the single deploy that resizes the instance (`COLORS_PAR_YANDEX_ALLOW_STOPPING_FOR_UPDATE=true`). Attaching a reserved address does not require it.
+
+Both keys default to `false`, which renders exactly as before.
 
 ### Oracle Cloud Infrastructure
 

--- a/test/parity/colors.yml
+++ b/test/parity/colors.yml
@@ -76,6 +76,10 @@ yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
 yandex-disk-size-gb: 20
+# Present as booleans so COLORS_PAR_* overrides are coerced to booleans: the
+# template engines agree on boolean truthiness, not on the string "false".
+yandex-static-ip: false
+yandex-allow-stopping-for-update: false
 oci-config-file-profile: DEFAULT
 oci-subnet-id: subnet
 oci-compartment-id: compartment


### PR DESCRIPTION
Yandex releases an ephemeral NAT address whenever an instance stops, so a restarted server comes back on a different IP and everything bound to the old one — DNS records, certificates, the managed ~/.ssh/config entry — silently breaks.

yandex-static-ip reserves a yandex_vpc_address and pins the instance's NAT to it. yandex-allow-stopping-for-update separately lets OpenTofu stop the instance for changes Yandex cannot apply in place (cores, memory, platform); off, such an apply fails naming the flag instead of taking a live server down mid-deploy.

Both keys ship in colors.yml as booleans defaulting to false, which renders exactly as before. Booleans deliberately: the three template engines agree on boolean truthiness but not on the string "false", and the COLORS_PAR_* overlay only preserves the boolean type when the key is present in desired state. The template is a shared resource, so the same bytes land in all three colours, and scripts/parity.sh gains a yandex-static variant covering the enabled side of both toggles.

Contract 10 -> 11: a launcher pinned older renders neither key and ignores both silently, so the server keeps its ephemeral address and loses it on the next stop.