### PR TITLE
fix!: a new image in the family should not plan a replacement

### DIFF
--- a/blue/src/package_once_blue/resources/tools/tofu/yandex/main.tf
+++ b/blue/src/package_once_blue/resources/tools/tofu/yandex/main.tf
@@ -15,10 +15,16 @@ provider "yandex" {
   zone      = "<{ yandex-zone }>"
 }
 
+<% if yandex-image-id|not-empty %># The image is pinned in desired state, so the server runs a known image and
+# an upstream release cannot move it. image_id forces replacement on the boot
+# disk, so moving this pin deliberately plans one.
+<% else %># Resolved from the family, which is whatever Yandex has published most
+# recently. Convenient for a first create; see the lifecycle block below for
+# why the resolved id is then left alone.
 data "yandex_compute_image" "ubuntu" {
   family = "<{ yandex-image-family }>"
 }
-
+<% endif %>
 resource "yandex_vpc_network" "network" {
   name = "<{ yandex-name }>"
 }
@@ -43,8 +49,9 @@ resource "yandex_compute_instance" "node1" {
 
   boot_disk {
     initialize_params {
-      image_id = data.yandex_compute_image.ubuntu.id
-      size     = <{ yandex-disk-size-gb }>
+<% if yandex-image-id|not-empty %>      image_id = "<{ yandex-image-id }>"
+<% else %>      image_id = data.yandex_compute_image.ubuntu.id
+<% endif %>      size     = <{ yandex-disk-size-gb }>
     }
   }
 
@@ -70,7 +77,16 @@ resource "yandex_compute_instance" "node1" {
   }
   lifecycle {
     prevent_destroy = <{ compute-prevent-destroy }>
-  }
+<% if yandex-image-id|not-empty %>    # No ignore_changes here on purpose: with the image pinned, changing
+    # yandex-image-id *should* plan a replacement, and prevent_destroy makes
+    # that a deliberate decision rather than a surprise.
+<% else %>    # A boot disk's image is immutable, so tracking a family plans a
+    # replacement of the whole server every time Yandex publishes a release —
+    # and with prevent_destroy set the plan fails rather than warns, blocking
+    # unrelated deploys. Keep the disk; update the OS in place. Pin
+    # yandex-image-id to state which image the server runs.
+    ignore_changes = [boot_disk[0].initialize_params[0].image_id]
+<% endif %>  }
 }
 
 output "params" {

--- a/colors.yml
+++ b/colors.yml
@@ -108,6 +108,14 @@ yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
 yandex-disk-size-gb: 20
+# Optional. Pins the boot image. Left unset, the image resolves from
+# yandex-image-family — whatever Yandex published most recently — and the
+# resolved id is then ignored on later applies, because a boot disk's image is
+# immutable and following the family would plan a replacement of the server on
+# every upstream release. Set it to the image you are actually running once the
+# stack is real; moving the pin then plans a replacement deliberately.
+# `tofu state show yandex_compute_instance.node1` reports it as image_id.
+# yandex-image-id: fd8...
 
 oci-config-file-profile: REPLACE_ME
 oci-subnet-id: REPLACE_ME

--- a/green/src/clj/io/github/getcolors/once/utils.clj
+++ b/green/src/clj/io/github/getcolors/once/utils.clj
@@ -41,8 +41,13 @@
      getcolors org. The launcher resolves these names directly, so one pinned
      older cannot find them. The rename also changes generated Terraform
      resource addresses, which existing stacks must migrate with
-     `tofu state mv` before their next apply -- see README.md."
-  10)
+     `tofu state mv` before their next apply -- see README.md.
+  11: :yandex-image-id pins the compute image, and the family path stops
+     tracking the resolved id (ignore_changes on the boot disk image). A
+     launcher pinned older renders the family lookup without the ignore, so a
+     Yandex release plans a replacement of the server and prevent_destroy
+     turns that plan into a failed apply, blocking unrelated deploys."
+  11)
 
 (defn registrable-domain
   "The DNS zone `host` belongs to: its last two labels. Multi-label suffixes

--- a/green/src/resources/io/github/getcolors/once/tools/tofu/yandex/main.tf
+++ b/green/src/resources/io/github/getcolors/once/tools/tofu/yandex/main.tf
@@ -15,10 +15,16 @@ provider "yandex" {
   zone      = "<{ yandex-zone }>"
 }
 
+<% if yandex-image-id|not-empty %># The image is pinned in desired state, so the server runs a known image and
+# an upstream release cannot move it. image_id forces replacement on the boot
+# disk, so moving this pin deliberately plans one.
+<% else %># Resolved from the family, which is whatever Yandex has published most
+# recently. Convenient for a first create; see the lifecycle block below for
+# why the resolved id is then left alone.
 data "yandex_compute_image" "ubuntu" {
   family = "<{ yandex-image-family }>"
 }
-
+<% endif %>
 resource "yandex_vpc_network" "network" {
   name = "<{ yandex-name }>"
 }
@@ -43,8 +49,9 @@ resource "yandex_compute_instance" "node1" {
 
   boot_disk {
     initialize_params {
-      image_id = data.yandex_compute_image.ubuntu.id
-      size     = <{ yandex-disk-size-gb }>
+<% if yandex-image-id|not-empty %>      image_id = "<{ yandex-image-id }>"
+<% else %>      image_id = data.yandex_compute_image.ubuntu.id
+<% endif %>      size     = <{ yandex-disk-size-gb }>
     }
   }
 
@@ -70,7 +77,16 @@ resource "yandex_compute_instance" "node1" {
   }
   lifecycle {
     prevent_destroy = <{ compute-prevent-destroy }>
-  }
+<% if yandex-image-id|not-empty %>    # No ignore_changes here on purpose: with the image pinned, changing
+    # yandex-image-id *should* plan a replacement, and prevent_destroy makes
+    # that a deliberate decision rather than a surprise.
+<% else %>    # A boot disk's image is immutable, so tracking a family plans a
+    # replacement of the whole server every time Yandex publishes a release —
+    # and with prevent_destroy set the plan fails rather than warns, blocking
+    # unrelated deploys. Keep the disk; update the OS in place. Pin
+    # yandex-image-id to state which image the server runs.
+    ignore_changes = [boot_disk[0].initialize_params[0].image_id]
+<% endif %>  }
 }
 
 output "params" {

--- a/green/test/clj/io/github/getcolors/once/tools_test.clj
+++ b/green/test/clj/io/github/getcolors/once/tools_test.clj
@@ -71,7 +71,47 @@
         (is (str/includes? main "cloud_id  = \"cloud-id\""))
         (is (str/includes? main
                            "ssh-keys = \"ubuntu:ssh-ed25519 AAAATEST operator\""))
-        (is (not (str/includes? main "a-real-yandex-token"))))
+        (is (not (str/includes? main "a-real-yandex-token")))
+        (testing "the family is followed, but its resolved id is left alone"
+          (is (str/includes? main "data \"yandex_compute_image\""))
+          (is (str/includes?
+               main
+               "ignore_changes = [boot_disk[0].initialize_params[0].image_id]"))))
+      (finally
+        (delete-tree! workdir)))))
+
+(deftest yandex-pins-the-image-when-one-is-named
+  (let [workdir (temp-dir)
+        opts {:workdir workdir
+              :profile "test"
+              :green/event :build
+              :provider-compute "yandex"
+              :provider-backend "local"
+              :compute-prevent-destroy true
+              :compute-pubkey "ssh-ed25519 AAAATEST operator"
+              :yandex-cloud-id "cloud-id"
+              :yandex-folder-id "folder-id"
+              :yandex-zone "ru-central1-a"
+              :yandex-image-family "ubuntu-2404-lts"
+              :yandex-image-id "fd8someimageid"
+              :yandex-name "once-test"
+              :yandex-subnet-cidr "10.0.0.0/24"
+              :yandex-platform-id "standard-v3"
+              :yandex-cores 2
+              :yandex-memory-gb 2
+              :yandex-core-fraction 100
+              :yandex-disk-size-gb 20}]
+    (try
+      (let [result (tools/tofu-compute-step opts)
+            main (slurp (io/file (tools/tool-dir opts "tofu-compute") "main.tf"))]
+        (is (zero? (:green/exit result)))
+        (is (str/includes? main "image_id = \"fd8someimageid\""))
+        (testing "the family lookup is gone, so nothing can move the image"
+          (is (not (str/includes? main "data \"yandex_compute_image\""))))
+        (testing "and moving the pin is allowed to plan a replacement"
+          ;; the directive, not the word: a comment above it explains why there
+          ;; is none
+          (is (not (str/includes? main "ignore_changes = [")))))
       (finally
         (delete-tree! workdir)))))
 

--- a/index.html
+++ b/index.html
@@ -961,8 +961,14 @@ yandex-platform-id: standard-v3
 yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
-yandex-disk-size-gb: 20</code></pre>
+yandex-disk-size-gb: 20
+yandex-image-id: fd8...   # optional; pins the boot image</code></pre>
       <p>Creates a network, subnet, NAT-enabled Ubuntu instance, and boot disk. <code>compute-pubkey</code> is installed for the <code>ubuntu</code> user; keep the private half in <code>ssh-agent</code>. Credential: <code>COLORS_PAR_YANDEX_TOKEN</code>, passed to OpenTofu as <code>YC_TOKEN</code>.</p>
+      <p><code>yandex-image-id</code> is optional and pins the boot image. Left unset, the image resolves from <code>yandex-image-family</code> — whatever Yandex published most recently — and the resolved id is then deliberately ignored on later applies: a boot disk's image is immutable, so following the family would plan a replacement of the whole server every time a new image appears, and with <code>compute-prevent-destroy: true</code> that plan fails rather than warns, blocking unrelated deploys. The server keeps its disk and updates the OS in place. Pin the id once the stack is real; <code>tofu state show yandex_compute_instance.node1</code> reports the running image as <code>image_id</code>. With it set, no family lookup is rendered at all.</p>
+      <div class="callout warning">
+        <span class="callout-title">Changing <code>yandex-image-id</code> replaces the server</span>
+        The boot image is not something an existing instance can be moved to in place. A changed value destroys and recreates the VM, taking any data not held elsewhere with it. <code>compute-prevent-destroy: true</code> — the default — turns that into a refused apply rather than a silent rebuild.
+      </div>
 
       <h3>Oracle Cloud Infrastructure</h3>
       <pre><code class="language-yaml">provider-compute: oci

--- a/red/resources/tools/tofu/yandex/main.tf
+++ b/red/resources/tools/tofu/yandex/main.tf
@@ -15,10 +15,16 @@ provider "yandex" {
   zone      = "<{ yandex-zone }>"
 }
 
+<% if yandex-image-id|not-empty %># The image is pinned in desired state, so the server runs a known image and
+# an upstream release cannot move it. image_id forces replacement on the boot
+# disk, so moving this pin deliberately plans one.
+<% else %># Resolved from the family, which is whatever Yandex has published most
+# recently. Convenient for a first create; see the lifecycle block below for
+# why the resolved id is then left alone.
 data "yandex_compute_image" "ubuntu" {
   family = "<{ yandex-image-family }>"
 }
-
+<% endif %>
 resource "yandex_vpc_network" "network" {
   name = "<{ yandex-name }>"
 }
@@ -43,8 +49,9 @@ resource "yandex_compute_instance" "node1" {
 
   boot_disk {
     initialize_params {
-      image_id = data.yandex_compute_image.ubuntu.id
-      size     = <{ yandex-disk-size-gb }>
+<% if yandex-image-id|not-empty %>      image_id = "<{ yandex-image-id }>"
+<% else %>      image_id = data.yandex_compute_image.ubuntu.id
+<% endif %>      size     = <{ yandex-disk-size-gb }>
     }
   }
 
@@ -70,7 +77,16 @@ resource "yandex_compute_instance" "node1" {
   }
   lifecycle {
     prevent_destroy = <{ compute-prevent-destroy }>
-  }
+<% if yandex-image-id|not-empty %>    # No ignore_changes here on purpose: with the image pinned, changing
+    # yandex-image-id *should* plan a replacement, and prevent_destroy makes
+    # that a deliberate decision rather than a surprise.
+<% else %>    # A boot disk's image is immutable, so tracking a family plans a
+    # replacement of the whole server every time Yandex publishes a release —
+    # and with prevent_destroy set the plan fails rather than warns, blocking
+    # unrelated deploys. Keep the disk; update the OS in place. Pin
+    # yandex-image-id to state which image the server runs.
+    ignore_changes = [boot_disk[0].initialize_params[0].image_id]
+<% endif %>  }
 }
 
 output "params" {

--- a/scripts/parity.sh
+++ b/scripts/parity.sh
@@ -36,6 +36,11 @@ build_variant google COLORS_PAR_PROVIDER_COMPUTE=google
 build_variant digitalocean-vpc COLORS_PAR_DIGITALOCEAN_VPC_UUID=vpc-123
 build_variant hcloud COLORS_PAR_PROVIDER_COMPUTE=hcloud
 build_variant yandex COLORS_PAR_PROVIDER_COMPUTE=yandex
+# Both sides of the yandex-image-id branch, like oci-pinned below: the
+# unpinned side renders a family data source plus an ignore_changes, the
+# pinned side renders neither.
+build_variant yandex-pinned COLORS_PAR_PROVIDER_COMPUTE=yandex \
+  COLORS_PAR_YANDEX_IMAGE_ID=fd8example
 build_variant oci COLORS_PAR_PROVIDER_COMPUTE=oci
 # Both sides of the oci-image-id branch. The unpinned side renders a data
 # source and the pinned side renders none, so a colour whose template engine

--- a/skills/package-once-green/green
+++ b/skills/package-once-green/green
@@ -35,7 +35,7 @@
   "Minimum io.github.getcolors/once contract this launcher requires.
   Guarded at run time so a stale pin fails loudly instead of rendering
   templates from an older commit."
-  10)
+  11)
 
 ;; Managed by `bb pin` — do not edit by hand.
 (def ^:private once-sha "adeb1f7738a11293bdde6343b16fddbfe92bb2ae")

--- a/skills/package-once-green/references/configuration.md
+++ b/skills/package-once-green/references/configuration.md
@@ -162,9 +162,19 @@ yandex-cores: 2
 yandex-memory-gb: 2
 yandex-core-fraction: 100
 yandex-disk-size-gb: 20
+yandex-image-id: fd8...   # optional; pins the boot image
 ```
 
 Green creates a network, subnet, NAT-enabled instance, and boot disk. The public key is installed for the `ubuntu` user; keep its private half in `ssh-agent`. Required credential: `COLORS_PAR_YANDEX_TOKEN`, passed to OpenTofu as the provider-native `YC_TOKEN`.
+
+`:yandex-image-id` is optional and pins the boot image. Unset, the image
+resolves from `:yandex-image-family` — whatever Yandex published most recently —
+and the resolved id is then deliberately ignored on later applies: a boot
+disk's image is immutable, so following the family would plan a replacement of
+the server on every upstream release, which `:compute-prevent-destroy` (true by
+default) turns into a failed apply blocking unrelated deploys. Set it once the
+stack is real; `tofu state show yandex_compute_instance.node1` reports the
+running image as `image_id`. Moving the pin plans a replacement deliberately.
 
 ### Oracle Cloud Infrastructure
 


### PR DESCRIPTION
The yandex template resolved the boot image from a family, and a family returns whatever Yandex published most recently. A boot disk's image is immutable, so the day a new ubuntu-2404-lts appears OpenTofu plans to destroy and recreate the server — and with compute-prevent-destroy true (the default) that plan fails rather than warns, blocking every deploy until someone finds the cause. Not hypothetical: it hit two days after provisioning, on an unrelated application change.

Two changes, mirroring oci-image-id:

- The family path stops tracking the image id — ignore_changes on the boot disk image. The server keeps its disk and updates the OS in place; adopting a new base image is a rebuild, not a side effect of someone else's release.
- A new optional yandex-image-id pins the image: the family data source is not rendered at all, and ignore_changes is deliberately absent, so moving the pin plans a replacement as a decision rather than a surprise.

The template is a shared resource, so the same bytes land in all three colours, and scripts/parity.sh gains a yandex-pinned variant covering both sides of the conditional, like oci-pinned.

Contract 10 -> 11: a launcher pinned older renders the family lookup without the ignore, so a Yandex release again plans a replacement and prevent_destroy turns it into a failed apply.

BREAKING CHANGE: the yandex family path now ignores later image-id changes; pin yandex-image-id to adopt a new base image deliberately.