### PR TITLE
feat: optional allow_stopping_for_update for google compute

### DIFF
--- a/blue/README.md
+++ b/blue/README.md
@@ -14,7 +14,8 @@ uv run python -m pytest -q
 Desired state is the `colors.yml` found by walking up from the working
 directory — the same file green and red read, so switching colours needs no
 change to it. Yandex compute supports `yandex-static-ip`,
-`yandex-allow-stopping-for-update`, and optional `yandex-image-id`. Yandex Cloud
+`yandex-allow-stopping-for-update`, and optional `yandex-image-id`; Google
+compute supports `google-allow-stopping-for-update`. Yandex Cloud
 DNS creates public zones and direct records with `provider-dns: yandex`.
 Secrets use `COLORS_PAR_*`; never put them in `colors.yml`. See
 the unified [`../index.html`](../index.html) manual and

--- a/blue/src/package_once_blue/resources/tools/tofu/google/main.tf
+++ b/blue/src/package_once_blue/resources/tools/tofu/google/main.tf
@@ -63,7 +63,12 @@ resource "google_compute_instance" "node1" {
       nat_ip = google_compute_address.node1.address
     }
   }
-
+<% if google-allow-stopping-for-update %>
+  # Google cannot change some attributes — the machine type among them — while
+  # the instance runs. Opt in so tofu may stop it briefly to apply such a
+  # change instead of failing the apply.
+  allow_stopping_for_update = true
+<% endif %>
   metadata = {
     ssh-keys = "ubuntu:${trimspace(file("<{ google-ssh-authorized-keys }>"))}"
   }

--- a/colors.yml
+++ b/colors.yml
@@ -155,6 +155,10 @@ google-image-id: REPLACE_ME
 google-subnet-cidr: 10.20.1.0/24
 google-boot-disk-size-gb: 30
 google-ssh-authorized-keys: ~/.ssh/id_ed25519.pub
+# Optional. Off, an apply that Google cannot perform in place (the machine
+# type among them) fails naming the flag instead of stopping the instance
+# mid-deploy. Enable it for the one deploy that resizes the instance.
+google-allow-stopping-for-update: false
 
 digitalocean-name: once
 digitalocean-region: ams3

--- a/green/README.md
+++ b/green/README.md
@@ -178,7 +178,8 @@ the remaining live checks are soft failures named in the report.
   `compute-pubkey` through instance metadata, and authenticates with
   `COLORS_PAR_YANDEX_TOKEN`. Set `yandex-static-ip: true` to reserve the public
   address across stop/start; `yandex-allow-stopping-for-update: true` separately
-  permits updates that require stopping the instance. `yandex-image-id`
+  permits updates that require stopping the instance, as
+  `google-allow-stopping-for-update: true` does for Google Cloud. `yandex-image-id`
   optionally pins the boot image; without it, later family releases are ignored
   to prevent surprise server replacement.
 - SMTP templates: Resend or `no-infra` SMTP settings.

--- a/green/src/clj/io/github/getcolors/once/utils.clj
+++ b/green/src/clj/io/github/getcolors/once/utils.clj
@@ -46,8 +46,12 @@
      :yandex-allow-stopping-for-update, and :yandex-image-id. The family image
      path also stops tracking later resolved ids. A launcher pinned older
      ignores the new keys and can still lose an ephemeral address or plan an
-     unexpected replacement when an image family moves."
-  11)
+     unexpected replacement when an image family moves.
+  12: Google compute gains :google-allow-stopping-for-update, letting tofu
+     stop the instance for changes Google cannot apply in place, the machine
+     type among them. A launcher pinned older ignores the key silently and
+     the resize apply keeps failing."
+  12)
 
 (defn registrable-domain
   "The DNS zone `host` belongs to: its last two labels. Multi-label suffixes

--- a/green/src/resources/io/github/getcolors/once/tools/tofu/google/main.tf
+++ b/green/src/resources/io/github/getcolors/once/tools/tofu/google/main.tf
@@ -63,7 +63,12 @@ resource "google_compute_instance" "node1" {
       nat_ip = google_compute_address.node1.address
     }
   }
-
+<% if google-allow-stopping-for-update %>
+  # Google cannot change some attributes — the machine type among them — while
+  # the instance runs. Opt in so tofu may stop it briefly to apply such a
+  # change instead of failing the apply.
+  allow_stopping_for_update = true
+<% endif %>
   metadata = {
     ssh-keys = "ubuntu:${trimspace(file("<{ google-ssh-authorized-keys }>"))}"
   }

--- a/green/test/clj/io/github/getcolors/once/tools_test.clj
+++ b/green/test/clj/io/github/getcolors/once/tools_test.clj
@@ -156,6 +156,40 @@
       (finally
         (delete-tree! workdir)))))
 
+(deftest google-may-stop-the-instance-only-when-asked
+  (let [workdir (temp-dir)
+        opts {:workdir workdir
+              :profile "test"
+              :green/event :build
+              :provider-compute "google"
+              :provider-backend "local"
+              :compute-prevent-destroy true
+              :google-project "example-project"
+              :google-region "europe-west4"
+              :google-zone "europe-west4-b"
+              :google-name "once-test"
+              :google-machine-type "t2a-standard-1"
+              :google-image-project "ubuntu-os-cloud"
+              :google-image-family "ubuntu-2404-lts-arm64"
+              :google-image-id "projects/ubuntu-os-cloud/global/images/ubuntu-example"
+              :google-subnet-cidr "10.20.1.0/24"
+              :google-boot-disk-size-gb 30
+              :google-ssh-authorized-keys "/tmp/once.pub"}]
+    (try
+      (testing "off by default, so a resize apply fails instead of stopping"
+        (let [result (tools/tofu-compute-step opts)
+              main (slurp (io/file (tools/tool-dir opts "tofu-compute") "main.tf"))]
+          (is (zero? (:green/exit result)))
+          (is (not (str/includes? main "allow_stopping_for_update")))))
+      (testing "opting in renders the flag"
+        (let [result (tools/tofu-compute-step
+                      (assoc opts :google-allow-stopping-for-update true))
+              main (slurp (io/file (tools/tool-dir opts "tofu-compute") "main.tf"))]
+          (is (zero? (:green/exit result)))
+          (is (str/includes? main "allow_stopping_for_update = true"))))
+      (finally
+        (delete-tree! workdir)))))
+
 (deftest ansible-once-never-renders-the-smtp-password
   (testing "resend defers the password to a play-time env lookup"
     (let [yaml (tools/ansible-once (once-opts "resend" "re_a_real_secret"))]

--- a/index.html
+++ b/index.html
@@ -925,8 +925,10 @@ google-image-family: ubuntu-2404-lts-arm64
 google-image-id: projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-arm64-v20260723
 google-subnet-cidr: 10.20.1.0/24
 google-boot-disk-size-gb: 30
-google-ssh-authorized-keys: ~/.ssh/id_ed25519.pub</code></pre>
+google-ssh-authorized-keys: ~/.ssh/id_ed25519.pub
+google-allow-stopping-for-update: false</code></pre>
       <p>Creates a custom VPC, subnet, firewall rule, static address, and Compute Engine instance. Authentication uses Application Default Credentials.</p>
+      <p><code>google-allow-stopping-for-update</code> lets OpenTofu stop the instance to apply a change Google cannot make in place, such as <code>google-machine-type</code>. Leave it off for a server carrying traffic — the apply then fails naming the flag rather than taking the instance down mid-deploy — and enable it for the one deploy that resizes the instance (<code>COLORS_PAR_GOOGLE_ALLOW_STOPPING_FOR_UPDATE=true</code>). It defaults to <code>false</code>, which renders exactly as before. The reserved <code>google_compute_address</code> already survives stop/start, so no address is lost either way.</p>
 
       <h3>DigitalOcean</h3>
       <pre><code class="language-yaml">provider-compute: digitalocean

--- a/red/README.md
+++ b/red/README.md
@@ -15,7 +15,8 @@ bun run typecheck
 Desired state is the `colors.yml` found by walking up from the working
 directory — the same file green and blue read, so switching colours needs no
 change to it. Yandex compute supports `yandex-static-ip`,
-`yandex-allow-stopping-for-update`, and optional `yandex-image-id`. Yandex Cloud
+`yandex-allow-stopping-for-update`, and optional `yandex-image-id`; Google
+compute supports `google-allow-stopping-for-update`. Yandex Cloud
 DNS creates public zones and direct records with `provider-dns: yandex`.
 Secrets use `COLORS_PAR_*`; never place them in `colors.yml`. See
 the unified [`../index.html`](../index.html) manual and

--- a/red/resources/tools/tofu/google/main.tf
+++ b/red/resources/tools/tofu/google/main.tf
@@ -63,7 +63,12 @@ resource "google_compute_instance" "node1" {
       nat_ip = google_compute_address.node1.address
     }
   }
-
+<% if google-allow-stopping-for-update %>
+  # Google cannot change some attributes — the machine type among them — while
+  # the instance runs. Opt in so tofu may stop it briefly to apply such a
+  # change instead of failing the apply.
+  allow_stopping_for_update = true
+<% endif %>
   metadata = {
     ssh-keys = "ubuntu:${trimspace(file("<{ google-ssh-authorized-keys }>"))}"
   }

--- a/scripts/parity.sh
+++ b/scripts/parity.sh
@@ -33,6 +33,10 @@ build_variant local
 build_variant azure COLORS_PAR_PROVIDER_COMPUTE=azure
 build_variant aws COLORS_PAR_PROVIDER_COMPUTE=aws
 build_variant google COLORS_PAR_PROVIDER_COMPUTE=google
+# The enabled side of the google-allow-stopping-for-update toggle; the fixture
+# carries the key as a boolean so the override is coerced to boolean true.
+build_variant google-stopping COLORS_PAR_PROVIDER_COMPUTE=google \
+  COLORS_PAR_GOOGLE_ALLOW_STOPPING_FOR_UPDATE=true
 build_variant digitalocean-vpc COLORS_PAR_DIGITALOCEAN_VPC_UUID=vpc-123
 build_variant hcloud COLORS_PAR_PROVIDER_COMPUTE=hcloud
 build_variant yandex COLORS_PAR_PROVIDER_COMPUTE=yandex

--- a/skills/package-once-blue/references/configuration.md
+++ b/skills/package-once-blue/references/configuration.md
@@ -68,6 +68,10 @@ that require stopping the instance. Both default to `false`.
 releases are ignored so they cannot replace the server unexpectedly. Changing
 the pin plans a replacement.
 
+For Google compute, `google-allow-stopping-for-update: true` permits updates
+that require stopping the instance, such as a machine-type change. Defaults to
+`false`.
+
 Credential suffixes are `DO_TOKEN`, `HCLOUD_TOKEN`, `YANDEX_TOKEN`,
 `RESEND_API_KEY`, `RESEND_PASSWORD`, `NO_INFRA_SMTP_PASSWORD`,
 `CLOUDFLARE_API_TOKEN`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`. Prefix

--- a/skills/package-once-green/green
+++ b/skills/package-once-green/green
@@ -35,7 +35,7 @@
   "Minimum io.github.getcolors/once contract this launcher requires.
   Guarded at run time so a stale pin fails loudly instead of rendering
   templates from an older commit."
-  11)
+  12)
 
 ;; Managed by `bb pin` — do not edit by hand.
 (def ^:private once-sha "d9679d8413ee1917757b166b571f1f24a2406aaf")

--- a/skills/package-once-green/references/configuration.md
+++ b/skills/package-once-green/references/configuration.md
@@ -114,9 +114,13 @@ google-image-id: projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-arm64-
 google-subnet-cidr: 10.20.1.0/24
 google-boot-disk-size-gb: 30
 google-ssh-authorized-keys: ~/.ssh/id_ed25519.pub
+# Optional:
+google-allow-stopping-for-update: false
 ```
 
 Google uses Application Default Credentials from `gcloud auth application-default login`. It creates a custom VPC, subnet, firewall rule, static address, and Compute Engine instance.
+
+`:google-allow-stopping-for-update` lets OpenTofu stop the instance to apply a change Google cannot make in place, such as `:google-machine-type`. Leave it off for a server that carries traffic: the apply then fails naming the flag instead of taking the instance down mid-deploy, and it can be enabled for the single deploy that resizes the instance (`COLORS_PAR_GOOGLE_ALLOW_STOPPING_FOR_UPDATE=true`). The reserved `google_compute_address` survives stop/start, so the server keeps its IP either way. Defaults to `false`, which renders exactly as before.
 
 ### DigitalOcean
 

--- a/skills/package-once-red/references/configuration.md
+++ b/skills/package-once-red/references/configuration.md
@@ -65,6 +65,10 @@ that require stopping the instance. Both default to `false`.
 releases are ignored so they cannot replace the server unexpectedly. Changing
 the pin plans a replacement.
 
+For Google compute, `google-allow-stopping-for-update: true` permits updates
+that require stopping the instance, such as a machine-type change. Defaults to
+`false`.
+
 Credentials use `COLORS_PAR_*`, the one namespace every colour shares:
 `DO_TOKEN`, `HCLOUD_TOKEN`, `YANDEX_TOKEN`, `RESEND_API_KEY`,
 `RESEND_PASSWORD`, `NO_INFRA_SMTP_PASSWORD`, `CLOUDFLARE_API_TOKEN`,

--- a/test/parity/colors.yml
+++ b/test/parity/colors.yml
@@ -54,6 +54,10 @@ google-image-id: projects/ubuntu-os-cloud/global/images/ubuntu-example
 google-subnet-cidr: 10.20.1.0/24
 google-boot-disk-size-gb: 30
 google-ssh-authorized-keys: /tmp/once.pub
+# A boolean like the yandex toggles: the template engines agree on boolean
+# truthiness, not on the string "false", and the COLORS_PAR_* override is only
+# coerced to boolean when the key is present.
+google-allow-stopping-for-update: false
 digitalocean-name: once
 digitalocean-region: ams3
 digitalocean-size: s-1vcpu-1gb-35gb-intel


### PR DESCRIPTION
Changing google-machine-type (and a few other attributes) is something Google cannot apply to a running instance: without the flag OpenTofu fails the apply outright. So google-allow-stopping-for-update opts in to tofu stopping the instance briefly for exactly that deploy, mirroring in yandex-allow-stopping-for-update. The reserved google_compute_address survives stop/start, so the server keeps its IP either way.

The key ships in colors.yml as a boolean defaulting to false — the three template engines agree on boolean truthiness, not on the string "false", and the COLORS_PAR_* overlay only preserves the boolean type when the key is present in desired state. Off renders exactly as before. The template is a shared resource, so the same bytes land in all three colours, and scripts/parity.sh gains a google-stopping variant covering the enabled side.

Contract 11 -> 12: a launcher pinned older ignores the key silently and the resize apply keeps failing.